### PR TITLE
fix(api): update api response types to use correct models

### DIFF
--- a/lib/core/api/adapter.dart
+++ b/lib/core/api/adapter.dart
@@ -21,7 +21,8 @@ class BetterAuthCallAdapter<T>
       // logger.e("Status: $status, Body: $body");
       return Result.err(
         BetterError(
-          message: res?.data?.message ?? e.message,
+          code: res?.data?['code'] ?? "ERROR",
+          message: res?.data?['message'] ?? e.message,
           stack: s.toString(),
         ),
       );

--- a/lib/core/api/better_auth_client.dart
+++ b/lib/core/api/better_auth_client.dart
@@ -51,7 +51,7 @@ abstract class BetterAuthClient {
   //   @Body(nullToAbsent: true) required SignInEmailBody body,
   // });
 
-  @POST('/forgot-password')
+  @POST('/forget-password')
   Future<Result<StatusResponse>> forgotPassword({
     @Body(nullToAbsent: true) required ForgotPasswordBody body,
   });

--- a/lib/core/api/better_auth_client.dart
+++ b/lib/core/api/better_auth_client.dart
@@ -16,6 +16,7 @@ import 'models/result/status_response.dart';
 import 'models/session/session_response.dart';
 import 'models/user/delete_user/delete_user_body.dart';
 import 'models/user/update_user/update_user_body.dart';
+import 'models/result/success_response.dart';
 
 part 'better_auth_client.g.dart';
 
@@ -87,7 +88,7 @@ abstract class BetterAuthClient {
   });
 
   @POST('/delete-user')
-  Future<Result<StatusResponse>> deleteUser({
+  Future<Result<SuccessResponse>> deleteUser({
     @Body(nullToAbsent: true) DeleteUserBody body = const DeleteUserBody(),
   });
 

--- a/lib/core/api/better_auth_client.g.dart
+++ b/lib/core/api/better_auth_client.g.dart
@@ -100,7 +100,7 @@ class _BetterAuthClient implements BetterAuthClient {
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            '/forgot-password',
+            '/forget-password',
             queryParameters: queryParameters,
             data: _data,
           )

--- a/lib/core/api/better_auth_client.g.dart
+++ b/lib/core/api/better_auth_client.g.dart
@@ -359,14 +359,14 @@ class _BetterAuthClient implements BetterAuthClient {
     );
   }
 
-  Future<HttpResponse<StatusResponse>> _deleteUser({
+  Future<HttpResponse<SuccessResponse>> _deleteUser({
     DeleteUserBody body = const DeleteUserBody(),
   }) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = body;
-    final _options = _setStreamType<Result<StatusResponse>>(
+    final _options = _setStreamType<Result<SuccessResponse>>(
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
@@ -377,9 +377,9 @@ class _BetterAuthClient implements BetterAuthClient {
           .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
     );
     final _result = await _dio.fetch<Map<String, dynamic>>(_options);
-    late StatusResponse _value;
+    late SuccessResponse _value;
     try {
-      _value = StatusResponse.fromJson(_result.data!);
+      _value = SuccessResponse.fromJson(_result.data!);
     } on Object catch (e, s) {
       errorLogger?.logError(e, s, _options);
       rethrow;
@@ -389,10 +389,10 @@ class _BetterAuthClient implements BetterAuthClient {
   }
 
   @override
-  Future<Result<StatusResponse>> deleteUser({
+  Future<Result<SuccessResponse>> deleteUser({
     DeleteUserBody body = const DeleteUserBody(),
   }) {
-    return BetterAuthCallAdapter<StatusResponse>().adapt(
+    return BetterAuthCallAdapter<SuccessResponse>().adapt(
       () => _deleteUser(body: body),
     );
   }

--- a/lib/core/api/default/sign_in/sign_in_better_auth.dart
+++ b/lib/core/api/default/sign_in/sign_in_better_auth.dart
@@ -1,7 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';
 
-import '../../../../plugins/phone/models/sign_in_phone_body.dart';
 import '../../adapter.dart';
 import '../../models/result/result.dart';
 import 'models/email/sign_in_email_body.dart';
@@ -38,9 +37,4 @@ abstract class SignInBetterAuth {
 
   @POST('/sign-in/anonymous')
   Future<Result<SignUpResponse>> anonymous();
-
-  @POST('/sign-in/phone-number')
-  Future<Result<SignUpResponse>> phoneNumber({
-    @Body(nullToAbsent: true) required SignInPhoneBody body,
-  });
 }

--- a/lib/core/api/default/sign_in/sign_in_better_auth.dart
+++ b/lib/core/api/default/sign_in/sign_in_better_auth.dart
@@ -4,12 +4,12 @@ import 'package:retrofit/retrofit.dart';
 import '../../../../plugins/phone/models/sign_in_phone_body.dart';
 import '../../adapter.dart';
 import '../../models/result/result.dart';
-import '../../models/session/session_response.dart';
 import 'models/email/sign_in_email_body.dart';
 import 'models/email/sign_in_email_response.dart';
 import 'models/social/sign_in_social_body.dart';
 import 'models/social/sign_in_social_response.dart';
 import 'models/username/sign_in_username_body.dart';
+import '../sign_up/models/sign_up_response/sign_up_response.dart';
 
 part 'sign_in_better_auth.g.dart';
 
@@ -37,10 +37,10 @@ abstract class SignInBetterAuth {
   });
 
   @POST('/sign-in/anonymous')
-  Future<Result<SessionResponse>> anonymous();
+  Future<Result<SignUpResponse>> anonymous();
 
   @POST('/sign-in/phone-number')
-  Future<Result<SessionResponse>> phoneNumber({
+  Future<Result<SignUpResponse>> phoneNumber({
     @Body(nullToAbsent: true) required SignInPhoneBody body,
   });
 }

--- a/lib/core/api/default/sign_in/sign_in_better_auth.g.dart
+++ b/lib/core/api/default/sign_in/sign_in_better_auth.g.dart
@@ -129,12 +129,12 @@ class _SignInBetterAuth implements SignInBetterAuth {
     );
   }
 
-  Future<HttpResponse<SessionResponse>> _anonymous() async {
+  Future<HttpResponse<SignUpResponse>> _anonymous() async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    final _options = _setStreamType<Result<SessionResponse>>(
+    final _options = _setStreamType<Result<SignUpResponse>>(
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
@@ -145,9 +145,9 @@ class _SignInBetterAuth implements SignInBetterAuth {
           .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
     );
     final _result = await _dio.fetch<Map<String, dynamic>>(_options);
-    late SessionResponse _value;
+    late SignUpResponse _value;
     try {
-      _value = SessionResponse.fromJson(_result.data!);
+      _value = SignUpResponse.fromJson(_result.data!);
     } on Object catch (e, s) {
       errorLogger?.logError(e, s, _options);
       rethrow;
@@ -157,18 +157,18 @@ class _SignInBetterAuth implements SignInBetterAuth {
   }
 
   @override
-  Future<Result<SessionResponse>> anonymous() {
-    return BetterAuthCallAdapter<SessionResponse>().adapt(() => _anonymous());
+  Future<Result<SignUpResponse>> anonymous() {
+    return BetterAuthCallAdapter<SignUpResponse>().adapt(() => _anonymous());
   }
 
-  Future<HttpResponse<SessionResponse>> _phoneNumber({
+  Future<HttpResponse<SignUpResponse>> _phoneNumber({
     required SignInPhoneBody body,
   }) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = body;
-    final _options = _setStreamType<Result<SessionResponse>>(
+    final _options = _setStreamType<Result<SignUpResponse>>(
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
@@ -179,9 +179,9 @@ class _SignInBetterAuth implements SignInBetterAuth {
           .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
     );
     final _result = await _dio.fetch<Map<String, dynamic>>(_options);
-    late SessionResponse _value;
+    late SignUpResponse _value;
     try {
-      _value = SessionResponse.fromJson(_result.data!);
+      _value = SignUpResponse.fromJson(_result.data!);
     } on Object catch (e, s) {
       errorLogger?.logError(e, s, _options);
       rethrow;
@@ -191,8 +191,8 @@ class _SignInBetterAuth implements SignInBetterAuth {
   }
 
   @override
-  Future<Result<SessionResponse>> phoneNumber({required SignInPhoneBody body}) {
-    return BetterAuthCallAdapter<SessionResponse>().adapt(
+  Future<Result<SignUpResponse>> phoneNumber({required SignInPhoneBody body}) {
+    return BetterAuthCallAdapter<SignUpResponse>().adapt(
       () => _phoneNumber(body: body),
     );
   }

--- a/lib/core/api/default/sign_in/sign_in_better_auth.g.dart
+++ b/lib/core/api/default/sign_in/sign_in_better_auth.g.dart
@@ -161,42 +161,6 @@ class _SignInBetterAuth implements SignInBetterAuth {
     return BetterAuthCallAdapter<SignUpResponse>().adapt(() => _anonymous());
   }
 
-  Future<HttpResponse<SignUpResponse>> _phoneNumber({
-    required SignInPhoneBody body,
-  }) async {
-    final _extra = <String, dynamic>{};
-    final queryParameters = <String, dynamic>{};
-    final _headers = <String, dynamic>{};
-    final _data = body;
-    final _options = _setStreamType<Result<SignUpResponse>>(
-      Options(method: 'POST', headers: _headers, extra: _extra)
-          .compose(
-            _dio.options,
-            '/sign-in/phone-number',
-            queryParameters: queryParameters,
-            data: _data,
-          )
-          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
-    );
-    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
-    late SignUpResponse _value;
-    try {
-      _value = SignUpResponse.fromJson(_result.data!);
-    } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
-      rethrow;
-    }
-    final httpResponse = HttpResponse(_value, _result);
-    return httpResponse;
-  }
-
-  @override
-  Future<Result<SignUpResponse>> phoneNumber({required SignInPhoneBody body}) {
-    return BetterAuthCallAdapter<SignUpResponse>().adapt(
-      () => _phoneNumber(body: body),
-    );
-  }
-
   RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
     if (T != dynamic &&
         !(requestOptions.responseType == ResponseType.bytes ||

--- a/lib/core/api/models/common/verify_email/verify_email_response.dart
+++ b/lib/core/api/models/common/verify_email/verify_email_response.dart
@@ -9,7 +9,7 @@ part 'verify_email_response.g.dart';
 @freezed
 abstract class VerifyEmailResponse with _$VerifyEmailResponse {
   const factory VerifyEmailResponse({
-    required User user,
+    required User? user,
     required bool status,
     String? required,
   }) = _VerifyEmailResponse;

--- a/lib/core/api/models/common/verify_email/verify_email_response.freezed.dart
+++ b/lib/core/api/models/common/verify_email/verify_email_response.freezed.dart
@@ -16,7 +16,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$VerifyEmailResponse {
 
- User get user; bool get status; String? get required;
+ User? get user; bool get status; String? get required;
 /// Create a copy of VerifyEmailResponse
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -49,11 +49,11 @@ abstract mixin class $VerifyEmailResponseCopyWith<$Res>  {
   factory $VerifyEmailResponseCopyWith(VerifyEmailResponse value, $Res Function(VerifyEmailResponse) _then) = _$VerifyEmailResponseCopyWithImpl;
 @useResult
 $Res call({
- User user, bool status, String? required
+ User? user, bool status, String? required
 });
 
 
-$UserCopyWith<$Res> get user;
+$UserCopyWith<$Res>? get user;
 
 }
 /// @nodoc
@@ -66,10 +66,10 @@ class _$VerifyEmailResponseCopyWithImpl<$Res>
 
 /// Create a copy of VerifyEmailResponse
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? user = null,Object? status = null,Object? required = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? user = freezed,Object? status = null,Object? required = freezed,}) {
   return _then(_self.copyWith(
-user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
-as User,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+user: freezed == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as User?,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
 as bool,required: freezed == required ? _self.required : required // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
@@ -78,9 +78,12 @@ as String?,
 /// with the given fields replaced by the non-null parameter values.
 @override
 @pragma('vm:prefer-inline')
-$UserCopyWith<$Res> get user {
-  
-  return $UserCopyWith<$Res>(_self.user, (value) {
+$UserCopyWith<$Res>? get user {
+    if (_self.user == null) {
+    return null;
+  }
+
+  return $UserCopyWith<$Res>(_self.user!, (value) {
     return _then(_self.copyWith(user: value));
   });
 }
@@ -94,7 +97,7 @@ class _VerifyEmailResponse implements VerifyEmailResponse {
   const _VerifyEmailResponse({required this.user, required this.status, this.required});
   factory _VerifyEmailResponse.fromJson(Map<String, dynamic> json) => _$VerifyEmailResponseFromJson(json);
 
-@override final  User user;
+@override final  User? user;
 @override final  bool status;
 @override final  String? required;
 
@@ -131,11 +134,11 @@ abstract mixin class _$VerifyEmailResponseCopyWith<$Res> implements $VerifyEmail
   factory _$VerifyEmailResponseCopyWith(_VerifyEmailResponse value, $Res Function(_VerifyEmailResponse) _then) = __$VerifyEmailResponseCopyWithImpl;
 @override @useResult
 $Res call({
- User user, bool status, String? required
+ User? user, bool status, String? required
 });
 
 
-@override $UserCopyWith<$Res> get user;
+@override $UserCopyWith<$Res>? get user;
 
 }
 /// @nodoc
@@ -148,10 +151,10 @@ class __$VerifyEmailResponseCopyWithImpl<$Res>
 
 /// Create a copy of VerifyEmailResponse
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? user = null,Object? status = null,Object? required = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? user = freezed,Object? status = null,Object? required = freezed,}) {
   return _then(_VerifyEmailResponse(
-user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
-as User,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+user: freezed == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as User?,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
 as bool,required: freezed == required ? _self.required : required // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
@@ -161,9 +164,12 @@ as String?,
 /// with the given fields replaced by the non-null parameter values.
 @override
 @pragma('vm:prefer-inline')
-$UserCopyWith<$Res> get user {
-  
-  return $UserCopyWith<$Res>(_self.user, (value) {
+$UserCopyWith<$Res>? get user {
+    if (_self.user == null) {
+    return null;
+  }
+
+  return $UserCopyWith<$Res>(_self.user!, (value) {
     return _then(_self.copyWith(user: value));
   });
 }

--- a/lib/core/api/models/common/verify_email/verify_email_response.g.dart
+++ b/lib/core/api/models/common/verify_email/verify_email_response.g.dart
@@ -8,7 +8,10 @@ part of 'verify_email_response.dart';
 
 _VerifyEmailResponse _$VerifyEmailResponseFromJson(Map<String, dynamic> json) =>
     _VerifyEmailResponse(
-      user: User.fromJson(json['user'] as Map<String, dynamic>),
+      user:
+          json['user'] == null
+              ? null
+              : User.fromJson(json['user'] as Map<String, dynamic>),
       status: json['status'] as bool,
       required: json['required'] as String?,
     );
@@ -16,7 +19,7 @@ _VerifyEmailResponse _$VerifyEmailResponseFromJson(Map<String, dynamic> json) =>
 Map<String, dynamic> _$VerifyEmailResponseToJson(
   _VerifyEmailResponse instance,
 ) => <String, dynamic>{
-  'user': instance.user.toJson(),
+  'user': instance.user?.toJson(),
   'status': instance.status,
   'required': instance.required,
 };

--- a/lib/core/api/models/result/success_response.dart
+++ b/lib/core/api/models/result/success_response.dart
@@ -1,0 +1,13 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'success_response.freezed.dart';
+part 'success_response.g.dart';
+
+@freezed
+abstract class SuccessResponse with _$SuccessResponse {
+  const factory SuccessResponse({required bool success, String? message}) =
+      _SuccessResponse;
+
+  factory SuccessResponse.fromJson(Map<String, dynamic> json) =>
+      _$SuccessResponseFromJson(json);
+}

--- a/lib/core/api/models/result/success_response.freezed.dart
+++ b/lib/core/api/models/result/success_response.freezed.dart
@@ -1,0 +1,151 @@
+// dart format width=80
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'success_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$SuccessResponse {
+
+ bool get success; String? get message;
+/// Create a copy of SuccessResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SuccessResponseCopyWith<SuccessResponse> get copyWith => _$SuccessResponseCopyWithImpl<SuccessResponse>(this as SuccessResponse, _$identity);
+
+  /// Serializes this SuccessResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SuccessResponse&&(identical(other.success, success) || other.success == success)&&(identical(other.message, message) || other.message == message));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,success,message);
+
+@override
+String toString() {
+  return 'SuccessResponse(success: $success, message: $message)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SuccessResponseCopyWith<$Res>  {
+  factory $SuccessResponseCopyWith(SuccessResponse value, $Res Function(SuccessResponse) _then) = _$SuccessResponseCopyWithImpl;
+@useResult
+$Res call({
+ bool success, String? message
+});
+
+
+
+
+}
+/// @nodoc
+class _$SuccessResponseCopyWithImpl<$Res>
+    implements $SuccessResponseCopyWith<$Res> {
+  _$SuccessResponseCopyWithImpl(this._self, this._then);
+
+  final SuccessResponse _self;
+  final $Res Function(SuccessResponse) _then;
+
+/// Create a copy of SuccessResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? success = null,Object? message = freezed,}) {
+  return _then(_self.copyWith(
+success: null == success ? _self.success : success // ignore: cast_nullable_to_non_nullable
+as bool,message: freezed == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _SuccessResponse implements SuccessResponse {
+  const _SuccessResponse({required this.success, this.message});
+  factory _SuccessResponse.fromJson(Map<String, dynamic> json) => _$SuccessResponseFromJson(json);
+
+@override final  bool success;
+@override final  String? message;
+
+/// Create a copy of SuccessResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$SuccessResponseCopyWith<_SuccessResponse> get copyWith => __$SuccessResponseCopyWithImpl<_SuccessResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$SuccessResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SuccessResponse&&(identical(other.success, success) || other.success == success)&&(identical(other.message, message) || other.message == message));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,success,message);
+
+@override
+String toString() {
+  return 'SuccessResponse(success: $success, message: $message)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$SuccessResponseCopyWith<$Res> implements $SuccessResponseCopyWith<$Res> {
+  factory _$SuccessResponseCopyWith(_SuccessResponse value, $Res Function(_SuccessResponse) _then) = __$SuccessResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ bool success, String? message
+});
+
+
+
+
+}
+/// @nodoc
+class __$SuccessResponseCopyWithImpl<$Res>
+    implements _$SuccessResponseCopyWith<$Res> {
+  __$SuccessResponseCopyWithImpl(this._self, this._then);
+
+  final _SuccessResponse _self;
+  final $Res Function(_SuccessResponse) _then;
+
+/// Create a copy of SuccessResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? success = null,Object? message = freezed,}) {
+  return _then(_SuccessResponse(
+success: null == success ? _self.success : success // ignore: cast_nullable_to_non_nullable
+as bool,message: freezed == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/core/api/models/result/success_response.g.dart
+++ b/lib/core/api/models/result/success_response.g.dart
@@ -1,0 +1,16 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'success_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_SuccessResponse _$SuccessResponseFromJson(Map<String, dynamic> json) =>
+    _SuccessResponse(
+      success: json['success'] as bool,
+      message: json['message'] as String?,
+    );
+
+Map<String, dynamic> _$SuccessResponseToJson(_SuccessResponse instance) =>
+    <String, dynamic>{'success': instance.success, 'message': instance.message};

--- a/lib/plugins/admin/admin_better_auth.dart
+++ b/lib/plugins/admin/admin_better_auth.dart
@@ -5,6 +5,7 @@ import '../../core/api/adapter.dart';
 import '../../core/api/models/result/result.dart';
 import '../../core/api/models/result/status_response.dart';
 import '../../core/api/models/session/session_response.dart';
+import '../../core/api/models/result/success_response.dart';
 import 'models/ban/ban_body.dart';
 import 'models/create_user/create_user_body.dart';
 import 'models/create_user/user_response.dart';
@@ -49,12 +50,12 @@ abstract class AdminBetterAuth {
   });
 
   @POST('/admin/revoke-user-sessions')
-  Future<Result<StatusResponse>> removeUserSessions({
+  Future<Result<SuccessResponse>> removeUserSessions({
     @Body(nullToAbsent: true) required Map<String, dynamic> body,
   });
 
   @POST('/admin/remove-user')
-  Future<Result<StatusResponse>> removeUser({
+  Future<Result<SuccessResponse>> removeUser({
     @Body(nullToAbsent: true) required BanBody body,
   });
 

--- a/lib/plugins/admin/admin_better_auth.g.dart
+++ b/lib/plugins/admin/admin_better_auth.g.dart
@@ -193,7 +193,7 @@ class _AdminBetterAuth implements AdminBetterAuth {
     );
   }
 
-  Future<HttpResponse<StatusResponse>> _removeUserSessions({
+  Future<HttpResponse<SuccessResponse>> _removeUserSessions({
     required Map<String, dynamic> body,
   }) async {
     final _extra = <String, dynamic>{};
@@ -202,7 +202,7 @@ class _AdminBetterAuth implements AdminBetterAuth {
     final _data = <String, dynamic>{};
     _data.addAll(body);
     _data.removeWhere((k, v) => v == null);
-    final _options = _setStreamType<Result<StatusResponse>>(
+    final _options = _setStreamType<Result<SuccessResponse>>(
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
@@ -213,9 +213,9 @@ class _AdminBetterAuth implements AdminBetterAuth {
           .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
     );
     final _result = await _dio.fetch<Map<String, dynamic>>(_options);
-    late StatusResponse _value;
+    late SuccessResponse _value;
     try {
-      _value = StatusResponse.fromJson(_result.data!);
+      _value = SuccessResponse.fromJson(_result.data!);
     } on Object catch (e, s) {
       errorLogger?.logError(e, s, _options);
       rethrow;
@@ -225,22 +225,22 @@ class _AdminBetterAuth implements AdminBetterAuth {
   }
 
   @override
-  Future<Result<StatusResponse>> removeUserSessions({
+  Future<Result<SuccessResponse>> removeUserSessions({
     required Map<String, dynamic> body,
   }) {
-    return BetterAuthCallAdapter<StatusResponse>().adapt(
+    return BetterAuthCallAdapter<SuccessResponse>().adapt(
       () => _removeUserSessions(body: body),
     );
   }
 
-  Future<HttpResponse<StatusResponse>> _removeUser({
+  Future<HttpResponse<SuccessResponse>> _removeUser({
     required BanBody body,
   }) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = body;
-    final _options = _setStreamType<Result<StatusResponse>>(
+    final _options = _setStreamType<Result<SuccessResponse>>(
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
@@ -251,9 +251,9 @@ class _AdminBetterAuth implements AdminBetterAuth {
           .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
     );
     final _result = await _dio.fetch<Map<String, dynamic>>(_options);
-    late StatusResponse _value;
+    late SuccessResponse _value;
     try {
-      _value = StatusResponse.fromJson(_result.data!);
+      _value = SuccessResponse.fromJson(_result.data!);
     } on Object catch (e, s) {
       errorLogger?.logError(e, s, _options);
       rethrow;
@@ -263,8 +263,8 @@ class _AdminBetterAuth implements AdminBetterAuth {
   }
 
   @override
-  Future<Result<StatusResponse>> removeUser({required BanBody body}) {
-    return BetterAuthCallAdapter<StatusResponse>().adapt(
+  Future<Result<SuccessResponse>> removeUser({required BanBody body}) {
+    return BetterAuthCallAdapter<SuccessResponse>().adapt(
       () => _removeUser(body: body),
     );
   }

--- a/lib/plugins/admin/models/create_user/user_response.dart
+++ b/lib/plugins/admin/models/create_user/user_response.dart
@@ -1,11 +1,12 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import '../../../../../core/models/user/user.dart';
 
 part 'user_response.freezed.dart';
 part 'user_response.g.dart';
 
 @freezed
 abstract class UserResponse with _$UserResponse {
-  const factory UserResponse({required String user}) = _UserResponse;
+  const factory UserResponse({required User user}) = _UserResponse;
 
   factory UserResponse.fromJson(Map<String, dynamic> json) =>
       _$UserResponseFromJson(json);

--- a/lib/plugins/admin/models/create_user/user_response.freezed.dart
+++ b/lib/plugins/admin/models/create_user/user_response.freezed.dart
@@ -16,7 +16,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$UserResponse {
 
- String get user;
+ User get user;
 /// Create a copy of UserResponse
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -49,11 +49,11 @@ abstract mixin class $UserResponseCopyWith<$Res>  {
   factory $UserResponseCopyWith(UserResponse value, $Res Function(UserResponse) _then) = _$UserResponseCopyWithImpl;
 @useResult
 $Res call({
- String user
+ User user
 });
 
 
-
+$UserCopyWith<$Res> get user;
 
 }
 /// @nodoc
@@ -69,10 +69,19 @@ class _$UserResponseCopyWithImpl<$Res>
 @pragma('vm:prefer-inline') @override $Res call({Object? user = null,}) {
   return _then(_self.copyWith(
 user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
-as String,
+as User,
   ));
 }
-
+/// Create a copy of UserResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserCopyWith<$Res> get user {
+  
+  return $UserCopyWith<$Res>(_self.user, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}
 }
 
 
@@ -83,7 +92,7 @@ class _UserResponse implements UserResponse {
   const _UserResponse({required this.user});
   factory _UserResponse.fromJson(Map<String, dynamic> json) => _$UserResponseFromJson(json);
 
-@override final  String user;
+@override final  User user;
 
 /// Create a copy of UserResponse
 /// with the given fields replaced by the non-null parameter values.
@@ -118,11 +127,11 @@ abstract mixin class _$UserResponseCopyWith<$Res> implements $UserResponseCopyWi
   factory _$UserResponseCopyWith(_UserResponse value, $Res Function(_UserResponse) _then) = __$UserResponseCopyWithImpl;
 @override @useResult
 $Res call({
- String user
+ User user
 });
 
 
-
+@override $UserCopyWith<$Res> get user;
 
 }
 /// @nodoc
@@ -138,11 +147,20 @@ class __$UserResponseCopyWithImpl<$Res>
 @override @pragma('vm:prefer-inline') $Res call({Object? user = null,}) {
   return _then(_UserResponse(
 user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
-as String,
+as User,
   ));
 }
 
-
+/// Create a copy of UserResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserCopyWith<$Res> get user {
+  
+  return $UserCopyWith<$Res>(_self.user, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}
 }
 
 // dart format on

--- a/lib/plugins/admin/models/create_user/user_response.g.dart
+++ b/lib/plugins/admin/models/create_user/user_response.g.dart
@@ -7,7 +7,7 @@ part of 'user_response.dart';
 // **************************************************************************
 
 _UserResponse _$UserResponseFromJson(Map<String, dynamic> json) =>
-    _UserResponse(user: json['user'] as String);
+    _UserResponse(user: User.fromJson(json['user'] as Map<String, dynamic>));
 
 Map<String, dynamic> _$UserResponseToJson(_UserResponse instance) =>
-    <String, dynamic>{'user': instance.user};
+    <String, dynamic>{'user': instance.user.toJson()};

--- a/lib/plugins/email_otp/email_otp_better_auth.dart
+++ b/lib/plugins/email_otp/email_otp_better_auth.dart
@@ -5,6 +5,7 @@ import '../../core/api/adapter.dart';
 import '../../core/api/default/sign_up/models/sign_up_response/sign_up_response.dart';
 import '../../core/api/models/result/result.dart';
 import '../../core/api/models/result/status_response.dart';
+import '../../core/api/models/result/success_response.dart';
 import 'models/reset_password/password_otp.dart';
 import 'models/verification_otp/otp_body.dart';
 import 'models/verify_otp/verify_otp_body.dart';
@@ -20,7 +21,7 @@ abstract class EmailOtpBetterAuth {
   }) = _EmailOtpBetterAuth;
 
   @POST('/email-otp/send-verification-otp')
-  Future<Result<StatusResponse>> sendVerification({
+  Future<Result<SuccessResponse>> sendVerification({
     @Body() required OtpBody body,
   });
 
@@ -33,12 +34,12 @@ abstract class EmailOtpBetterAuth {
   Future<Result<SignUpResponse>> signIn({@Body() required VerifyOtpBody body});
 
   @POST('/forget-password/email-otp')
-  Future<Result<StatusResponse>> forgotPassword({
+  Future<Result<SuccessResponse>> forgotPassword({
     @Body() required OtpBody body,
   });
 
   @POST('/email-otp/reset-password')
-  Future<Result<StatusResponse>> resetPassword({
+  Future<Result<SuccessResponse>> resetPassword({
     @Body() required PasswordOtpBody body,
   });
 }

--- a/lib/plugins/email_otp/email_otp_better_auth.dart
+++ b/lib/plugins/email_otp/email_otp_better_auth.dart
@@ -8,6 +8,7 @@ import '../../core/api/models/result/success_response.dart';
 import 'models/reset_password/password_otp.dart';
 import 'models/verification_otp/otp_body.dart';
 import 'models/verify_otp/verify_otp_body.dart';
+import 'models/verification_otp/email_otp_body.dart';
 
 part 'email_otp_better_auth.g.dart';
 
@@ -21,7 +22,7 @@ abstract class EmailOtpBetterAuth {
 
   @POST('/email-otp/send-verification-otp')
   Future<Result<SuccessResponse>> sendVerification({
-    @Body() required OtpBody body,
+    @Body() required EmailOtpBody body,
   });
 
   @POST('/email-otp/verify-email')

--- a/lib/plugins/email_otp/email_otp_better_auth.dart
+++ b/lib/plugins/email_otp/email_otp_better_auth.dart
@@ -4,7 +4,6 @@ import 'package:retrofit/retrofit.dart';
 import '../../core/api/adapter.dart';
 import '../../core/api/default/sign_up/models/sign_up_response/sign_up_response.dart';
 import '../../core/api/models/result/result.dart';
-import '../../core/api/models/result/status_response.dart';
 import '../../core/api/models/result/success_response.dart';
 import 'models/reset_password/password_otp.dart';
 import 'models/verification_otp/otp_body.dart';

--- a/lib/plugins/email_otp/email_otp_better_auth.g.dart
+++ b/lib/plugins/email_otp/email_otp_better_auth.g.dart
@@ -18,7 +18,7 @@ class _EmailOtpBetterAuth implements EmailOtpBetterAuth {
   final ParseErrorLogger? errorLogger;
 
   Future<HttpResponse<SuccessResponse>> _sendVerification({
-    required OtpBody body,
+    required EmailOtpBody body,
   }) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
@@ -47,7 +47,9 @@ class _EmailOtpBetterAuth implements EmailOtpBetterAuth {
   }
 
   @override
-  Future<Result<SuccessResponse>> sendVerification({required OtpBody body}) {
+  Future<Result<SuccessResponse>> sendVerification({
+    required EmailOtpBody body,
+  }) {
     return BetterAuthCallAdapter<SuccessResponse>().adapt(
       () => _sendVerification(body: body),
     );

--- a/lib/plugins/email_otp/email_otp_better_auth.g.dart
+++ b/lib/plugins/email_otp/email_otp_better_auth.g.dart
@@ -17,14 +17,14 @@ class _EmailOtpBetterAuth implements EmailOtpBetterAuth {
 
   final ParseErrorLogger? errorLogger;
 
-  Future<HttpResponse<StatusResponse>> _sendVerification({
+  Future<HttpResponse<SuccessResponse>> _sendVerification({
     required OtpBody body,
   }) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = body;
-    final _options = _setStreamType<Result<StatusResponse>>(
+    final _options = _setStreamType<Result<SuccessResponse>>(
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
@@ -35,9 +35,9 @@ class _EmailOtpBetterAuth implements EmailOtpBetterAuth {
           .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
     );
     final _result = await _dio.fetch<Map<String, dynamic>>(_options);
-    late StatusResponse _value;
+    late SuccessResponse _value;
     try {
-      _value = StatusResponse.fromJson(_result.data!);
+      _value = SuccessResponse.fromJson(_result.data!);
     } on Object catch (e, s) {
       errorLogger?.logError(e, s, _options);
       rethrow;
@@ -47,8 +47,8 @@ class _EmailOtpBetterAuth implements EmailOtpBetterAuth {
   }
 
   @override
-  Future<Result<StatusResponse>> sendVerification({required OtpBody body}) {
-    return BetterAuthCallAdapter<StatusResponse>().adapt(
+  Future<Result<SuccessResponse>> sendVerification({required OtpBody body}) {
+    return BetterAuthCallAdapter<SuccessResponse>().adapt(
       () => _sendVerification(body: body),
     );
   }
@@ -125,14 +125,14 @@ class _EmailOtpBetterAuth implements EmailOtpBetterAuth {
     );
   }
 
-  Future<HttpResponse<StatusResponse>> _forgotPassword({
+  Future<HttpResponse<SuccessResponse>> _forgotPassword({
     required OtpBody body,
   }) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = body;
-    final _options = _setStreamType<Result<StatusResponse>>(
+    final _options = _setStreamType<Result<SuccessResponse>>(
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
@@ -143,9 +143,9 @@ class _EmailOtpBetterAuth implements EmailOtpBetterAuth {
           .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
     );
     final _result = await _dio.fetch<Map<String, dynamic>>(_options);
-    late StatusResponse _value;
+    late SuccessResponse _value;
     try {
-      _value = StatusResponse.fromJson(_result.data!);
+      _value = SuccessResponse.fromJson(_result.data!);
     } on Object catch (e, s) {
       errorLogger?.logError(e, s, _options);
       rethrow;
@@ -155,20 +155,20 @@ class _EmailOtpBetterAuth implements EmailOtpBetterAuth {
   }
 
   @override
-  Future<Result<StatusResponse>> forgotPassword({required OtpBody body}) {
-    return BetterAuthCallAdapter<StatusResponse>().adapt(
+  Future<Result<SuccessResponse>> forgotPassword({required OtpBody body}) {
+    return BetterAuthCallAdapter<SuccessResponse>().adapt(
       () => _forgotPassword(body: body),
     );
   }
 
-  Future<HttpResponse<StatusResponse>> _resetPassword({
+  Future<HttpResponse<SuccessResponse>> _resetPassword({
     required PasswordOtpBody body,
   }) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = body;
-    final _options = _setStreamType<Result<StatusResponse>>(
+    final _options = _setStreamType<Result<SuccessResponse>>(
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
@@ -179,9 +179,9 @@ class _EmailOtpBetterAuth implements EmailOtpBetterAuth {
           .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
     );
     final _result = await _dio.fetch<Map<String, dynamic>>(_options);
-    late StatusResponse _value;
+    late SuccessResponse _value;
     try {
-      _value = StatusResponse.fromJson(_result.data!);
+      _value = SuccessResponse.fromJson(_result.data!);
     } on Object catch (e, s) {
       errorLogger?.logError(e, s, _options);
       rethrow;
@@ -191,10 +191,10 @@ class _EmailOtpBetterAuth implements EmailOtpBetterAuth {
   }
 
   @override
-  Future<Result<StatusResponse>> resetPassword({
+  Future<Result<SuccessResponse>> resetPassword({
     required PasswordOtpBody body,
   }) {
-    return BetterAuthCallAdapter<StatusResponse>().adapt(
+    return BetterAuthCallAdapter<SuccessResponse>().adapt(
       () => _resetPassword(body: body),
     );
   }

--- a/lib/plugins/email_otp/email_otp_plugin.dart
+++ b/lib/plugins/email_otp/email_otp_plugin.dart
@@ -1,5 +1,6 @@
 export 'email_otp_better_auth.dart';
 export 'models/reset_password/password_otp.dart';
 export 'models/verification_otp/otp_body.dart';
+export 'models/verification_otp/email_otp_body.dart';
 export 'models/verify_otp/verify_otp_body.dart';
 export 'email_otp_extension.dart';

--- a/lib/plugins/email_otp/models/verification_otp/email_otp_body.dart
+++ b/lib/plugins/email_otp/models/verification_otp/email_otp_body.dart
@@ -1,5 +1,4 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import './email_otp_type.dart';
 
 part 'email_otp_body.freezed.dart';
 part 'email_otp_body.g.dart';

--- a/lib/plugins/email_otp/models/verification_otp/email_otp_body.dart
+++ b/lib/plugins/email_otp/models/verification_otp/email_otp_body.dart
@@ -1,0 +1,14 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import './email_otp_type.dart';
+
+part 'email_otp_body.freezed.dart';
+part 'email_otp_body.g.dart';
+
+@freezed
+abstract class EmailOtpBody with _$EmailOtpBody {
+  const factory EmailOtpBody({required String email, required String type}) =
+      _EmailOtpBody;
+
+  factory EmailOtpBody.fromJson(Map<String, dynamic> json) =>
+      _$EmailOtpBodyFromJson(json);
+}

--- a/lib/plugins/email_otp/models/verification_otp/email_otp_body.freezed.dart
+++ b/lib/plugins/email_otp/models/verification_otp/email_otp_body.freezed.dart
@@ -1,0 +1,151 @@
+// dart format width=80
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'email_otp_body.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$EmailOtpBody {
+
+ String get email; String get type;
+/// Create a copy of EmailOtpBody
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$EmailOtpBodyCopyWith<EmailOtpBody> get copyWith => _$EmailOtpBodyCopyWithImpl<EmailOtpBody>(this as EmailOtpBody, _$identity);
+
+  /// Serializes this EmailOtpBody to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EmailOtpBody&&(identical(other.email, email) || other.email == email)&&(identical(other.type, type) || other.type == type));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,email,type);
+
+@override
+String toString() {
+  return 'EmailOtpBody(email: $email, type: $type)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $EmailOtpBodyCopyWith<$Res>  {
+  factory $EmailOtpBodyCopyWith(EmailOtpBody value, $Res Function(EmailOtpBody) _then) = _$EmailOtpBodyCopyWithImpl;
+@useResult
+$Res call({
+ String email, String type
+});
+
+
+
+
+}
+/// @nodoc
+class _$EmailOtpBodyCopyWithImpl<$Res>
+    implements $EmailOtpBodyCopyWith<$Res> {
+  _$EmailOtpBodyCopyWithImpl(this._self, this._then);
+
+  final EmailOtpBody _self;
+  final $Res Function(EmailOtpBody) _then;
+
+/// Create a copy of EmailOtpBody
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? email = null,Object? type = null,}) {
+  return _then(_self.copyWith(
+email: null == email ? _self.email : email // ignore: cast_nullable_to_non_nullable
+as String,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _EmailOtpBody implements EmailOtpBody {
+  const _EmailOtpBody({required this.email, required this.type});
+  factory _EmailOtpBody.fromJson(Map<String, dynamic> json) => _$EmailOtpBodyFromJson(json);
+
+@override final  String email;
+@override final  String type;
+
+/// Create a copy of EmailOtpBody
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$EmailOtpBodyCopyWith<_EmailOtpBody> get copyWith => __$EmailOtpBodyCopyWithImpl<_EmailOtpBody>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$EmailOtpBodyToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EmailOtpBody&&(identical(other.email, email) || other.email == email)&&(identical(other.type, type) || other.type == type));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,email,type);
+
+@override
+String toString() {
+  return 'EmailOtpBody(email: $email, type: $type)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$EmailOtpBodyCopyWith<$Res> implements $EmailOtpBodyCopyWith<$Res> {
+  factory _$EmailOtpBodyCopyWith(_EmailOtpBody value, $Res Function(_EmailOtpBody) _then) = __$EmailOtpBodyCopyWithImpl;
+@override @useResult
+$Res call({
+ String email, String type
+});
+
+
+
+
+}
+/// @nodoc
+class __$EmailOtpBodyCopyWithImpl<$Res>
+    implements _$EmailOtpBodyCopyWith<$Res> {
+  __$EmailOtpBodyCopyWithImpl(this._self, this._then);
+
+  final _EmailOtpBody _self;
+  final $Res Function(_EmailOtpBody) _then;
+
+/// Create a copy of EmailOtpBody
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? email = null,Object? type = null,}) {
+  return _then(_EmailOtpBody(
+email: null == email ? _self.email : email // ignore: cast_nullable_to_non_nullable
+as String,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/plugins/email_otp/models/verification_otp/email_otp_body.g.dart
+++ b/lib/plugins/email_otp/models/verification_otp/email_otp_body.g.dart
@@ -1,0 +1,13 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'email_otp_body.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_EmailOtpBody _$EmailOtpBodyFromJson(Map<String, dynamic> json) =>
+    _EmailOtpBody(email: json['email'] as String, type: json['type'] as String);
+
+Map<String, dynamic> _$EmailOtpBodyToJson(_EmailOtpBody instance) =>
+    <String, dynamic>{'email': instance.email, 'type': instance.type};

--- a/lib/plugins/email_otp/models/verification_otp/otp_body.dart
+++ b/lib/plugins/email_otp/models/verification_otp/otp_body.dart
@@ -6,7 +6,7 @@ part 'otp_body.g.dart';
 
 @freezed
 abstract class OtpBody with _$OtpBody {
-  const factory OtpBody({required String email, String? type}) = _OtpBody;
+  const factory OtpBody({required String email}) = _OtpBody;
 
   factory OtpBody.fromJson(Map<String, dynamic> json) =>
       _$OtpBodyFromJson(json);

--- a/lib/plugins/email_otp/models/verification_otp/otp_body.freezed.dart
+++ b/lib/plugins/email_otp/models/verification_otp/otp_body.freezed.dart
@@ -16,7 +16,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$OtpBody {
 
- String get email; String? get type;
+ String get email;
 /// Create a copy of OtpBody
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -29,16 +29,16 @@ $OtpBodyCopyWith<OtpBody> get copyWith => _$OtpBodyCopyWithImpl<OtpBody>(this as
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is OtpBody&&(identical(other.email, email) || other.email == email)&&(identical(other.type, type) || other.type == type));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is OtpBody&&(identical(other.email, email) || other.email == email));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,email,type);
+int get hashCode => Object.hash(runtimeType,email);
 
 @override
 String toString() {
-  return 'OtpBody(email: $email, type: $type)';
+  return 'OtpBody(email: $email)';
 }
 
 
@@ -49,7 +49,7 @@ abstract mixin class $OtpBodyCopyWith<$Res>  {
   factory $OtpBodyCopyWith(OtpBody value, $Res Function(OtpBody) _then) = _$OtpBodyCopyWithImpl;
 @useResult
 $Res call({
- String email, String? type
+ String email
 });
 
 
@@ -66,11 +66,10 @@ class _$OtpBodyCopyWithImpl<$Res>
 
 /// Create a copy of OtpBody
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? email = null,Object? type = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? email = null,}) {
   return _then(_self.copyWith(
 email: null == email ? _self.email : email // ignore: cast_nullable_to_non_nullable
-as String,type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
-as String?,
+as String,
   ));
 }
 
@@ -81,11 +80,10 @@ as String?,
 @JsonSerializable()
 
 class _OtpBody implements OtpBody {
-  const _OtpBody({required this.email, this.type});
+  const _OtpBody({required this.email});
   factory _OtpBody.fromJson(Map<String, dynamic> json) => _$OtpBodyFromJson(json);
 
 @override final  String email;
-@override final  String? type;
 
 /// Create a copy of OtpBody
 /// with the given fields replaced by the non-null parameter values.
@@ -100,16 +98,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _OtpBody&&(identical(other.email, email) || other.email == email)&&(identical(other.type, type) || other.type == type));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _OtpBody&&(identical(other.email, email) || other.email == email));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,email,type);
+int get hashCode => Object.hash(runtimeType,email);
 
 @override
 String toString() {
-  return 'OtpBody(email: $email, type: $type)';
+  return 'OtpBody(email: $email)';
 }
 
 
@@ -120,7 +118,7 @@ abstract mixin class _$OtpBodyCopyWith<$Res> implements $OtpBodyCopyWith<$Res> {
   factory _$OtpBodyCopyWith(_OtpBody value, $Res Function(_OtpBody) _then) = __$OtpBodyCopyWithImpl;
 @override @useResult
 $Res call({
- String email, String? type
+ String email
 });
 
 
@@ -137,11 +135,10 @@ class __$OtpBodyCopyWithImpl<$Res>
 
 /// Create a copy of OtpBody
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? email = null,Object? type = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? email = null,}) {
   return _then(_OtpBody(
 email: null == email ? _self.email : email // ignore: cast_nullable_to_non_nullable
-as String,type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
-as String?,
+as String,
   ));
 }
 

--- a/lib/plugins/email_otp/models/verification_otp/otp_body.g.dart
+++ b/lib/plugins/email_otp/models/verification_otp/otp_body.g.dart
@@ -7,9 +7,8 @@ part of 'otp_body.dart';
 // **************************************************************************
 
 _OtpBody _$OtpBodyFromJson(Map<String, dynamic> json) =>
-    _OtpBody(email: json['email'] as String, type: json['type'] as String?);
+    _OtpBody(email: json['email'] as String);
 
 Map<String, dynamic> _$OtpBodyToJson(_OtpBody instance) => <String, dynamic>{
   'email': instance.email,
-  'type': instance.type,
 };

--- a/lib/plugins/phone/models/reset/reset_phone_password_body.dart
+++ b/lib/plugins/phone/models/reset/reset_phone_password_body.dart
@@ -5,7 +5,11 @@ part 'reset_phone_password_body.g.dart';
 
 @freezed
 abstract class ResetPhonePasswordBody with _$ResetPhonePasswordBody {
-  const factory ResetPhonePasswordBody() = _ResetPhonePasswordBody;
+  const factory ResetPhonePasswordBody({
+    required String otp,
+    required String phoneNumber,
+    required String newPassword,
+  }) = _ResetPhonePasswordBody;
 
   factory ResetPhonePasswordBody.fromJson(Map<String, dynamic> json) =>
       _$ResetPhonePasswordBodyFromJson(json);

--- a/lib/plugins/phone/models/reset/reset_phone_password_body.freezed.dart
+++ b/lib/plugins/phone/models/reset/reset_phone_password_body.freezed.dart
@@ -16,7 +16,12 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$ResetPhonePasswordBody {
 
-
+ String get otp; String get phoneNumber; String get newPassword;
+/// Create a copy of ResetPhonePasswordBody
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ResetPhonePasswordBodyCopyWith<ResetPhonePasswordBody> get copyWith => _$ResetPhonePasswordBodyCopyWithImpl<ResetPhonePasswordBody>(this as ResetPhonePasswordBody, _$identity);
 
   /// Serializes this ResetPhonePasswordBody to a JSON map.
   Map<String, dynamic> toJson();
@@ -24,24 +29,52 @@ mixin _$ResetPhonePasswordBody {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ResetPhonePasswordBody);
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ResetPhonePasswordBody&&(identical(other.otp, otp) || other.otp == otp)&&(identical(other.phoneNumber, phoneNumber) || other.phoneNumber == phoneNumber)&&(identical(other.newPassword, newPassword) || other.newPassword == newPassword));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => runtimeType.hashCode;
+int get hashCode => Object.hash(runtimeType,otp,phoneNumber,newPassword);
 
 @override
 String toString() {
-  return 'ResetPhonePasswordBody()';
+  return 'ResetPhonePasswordBody(otp: $otp, phoneNumber: $phoneNumber, newPassword: $newPassword)';
 }
 
 
 }
 
 /// @nodoc
-class $ResetPhonePasswordBodyCopyWith<$Res>  {
-$ResetPhonePasswordBodyCopyWith(ResetPhonePasswordBody _, $Res Function(ResetPhonePasswordBody) __);
+abstract mixin class $ResetPhonePasswordBodyCopyWith<$Res>  {
+  factory $ResetPhonePasswordBodyCopyWith(ResetPhonePasswordBody value, $Res Function(ResetPhonePasswordBody) _then) = _$ResetPhonePasswordBodyCopyWithImpl;
+@useResult
+$Res call({
+ String otp, String phoneNumber, String newPassword
+});
+
+
+
+
+}
+/// @nodoc
+class _$ResetPhonePasswordBodyCopyWithImpl<$Res>
+    implements $ResetPhonePasswordBodyCopyWith<$Res> {
+  _$ResetPhonePasswordBodyCopyWithImpl(this._self, this._then);
+
+  final ResetPhonePasswordBody _self;
+  final $Res Function(ResetPhonePasswordBody) _then;
+
+/// Create a copy of ResetPhonePasswordBody
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? otp = null,Object? phoneNumber = null,Object? newPassword = null,}) {
+  return _then(_self.copyWith(
+otp: null == otp ? _self.otp : otp // ignore: cast_nullable_to_non_nullable
+as String,phoneNumber: null == phoneNumber ? _self.phoneNumber : phoneNumber // ignore: cast_nullable_to_non_nullable
+as String,newPassword: null == newPassword ? _self.newPassword : newPassword // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
 }
 
 
@@ -49,11 +82,18 @@ $ResetPhonePasswordBodyCopyWith(ResetPhonePasswordBody _, $Res Function(ResetPho
 @JsonSerializable()
 
 class _ResetPhonePasswordBody implements ResetPhonePasswordBody {
-  const _ResetPhonePasswordBody();
+  const _ResetPhonePasswordBody({required this.otp, required this.phoneNumber, required this.newPassword});
   factory _ResetPhonePasswordBody.fromJson(Map<String, dynamic> json) => _$ResetPhonePasswordBodyFromJson(json);
 
+@override final  String otp;
+@override final  String phoneNumber;
+@override final  String newPassword;
 
-
+/// Create a copy of ResetPhonePasswordBody
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ResetPhonePasswordBodyCopyWith<_ResetPhonePasswordBody> get copyWith => __$ResetPhonePasswordBodyCopyWithImpl<_ResetPhonePasswordBody>(this, _$identity);
 
 @override
 Map<String, dynamic> toJson() {
@@ -62,22 +102,53 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ResetPhonePasswordBody);
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ResetPhonePasswordBody&&(identical(other.otp, otp) || other.otp == otp)&&(identical(other.phoneNumber, phoneNumber) || other.phoneNumber == phoneNumber)&&(identical(other.newPassword, newPassword) || other.newPassword == newPassword));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => runtimeType.hashCode;
+int get hashCode => Object.hash(runtimeType,otp,phoneNumber,newPassword);
 
 @override
 String toString() {
-  return 'ResetPhonePasswordBody()';
+  return 'ResetPhonePasswordBody(otp: $otp, phoneNumber: $phoneNumber, newPassword: $newPassword)';
 }
 
 
 }
 
+/// @nodoc
+abstract mixin class _$ResetPhonePasswordBodyCopyWith<$Res> implements $ResetPhonePasswordBodyCopyWith<$Res> {
+  factory _$ResetPhonePasswordBodyCopyWith(_ResetPhonePasswordBody value, $Res Function(_ResetPhonePasswordBody) _then) = __$ResetPhonePasswordBodyCopyWithImpl;
+@override @useResult
+$Res call({
+ String otp, String phoneNumber, String newPassword
+});
 
 
+
+
+}
+/// @nodoc
+class __$ResetPhonePasswordBodyCopyWithImpl<$Res>
+    implements _$ResetPhonePasswordBodyCopyWith<$Res> {
+  __$ResetPhonePasswordBodyCopyWithImpl(this._self, this._then);
+
+  final _ResetPhonePasswordBody _self;
+  final $Res Function(_ResetPhonePasswordBody) _then;
+
+/// Create a copy of ResetPhonePasswordBody
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? otp = null,Object? phoneNumber = null,Object? newPassword = null,}) {
+  return _then(_ResetPhonePasswordBody(
+otp: null == otp ? _self.otp : otp // ignore: cast_nullable_to_non_nullable
+as String,phoneNumber: null == phoneNumber ? _self.phoneNumber : phoneNumber // ignore: cast_nullable_to_non_nullable
+as String,newPassword: null == newPassword ? _self.newPassword : newPassword // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
 
 // dart format on

--- a/lib/plugins/phone/models/reset/reset_phone_password_body.g.dart
+++ b/lib/plugins/phone/models/reset/reset_phone_password_body.g.dart
@@ -8,8 +8,16 @@ part of 'reset_phone_password_body.dart';
 
 _ResetPhonePasswordBody _$ResetPhonePasswordBodyFromJson(
   Map<String, dynamic> json,
-) => _ResetPhonePasswordBody();
+) => _ResetPhonePasswordBody(
+  otp: json['otp'] as String,
+  phoneNumber: json['phoneNumber'] as String,
+  newPassword: json['newPassword'] as String,
+);
 
 Map<String, dynamic> _$ResetPhonePasswordBodyToJson(
   _ResetPhonePasswordBody instance,
-) => <String, dynamic>{};
+) => <String, dynamic>{
+  'otp': instance.otp,
+  'phoneNumber': instance.phoneNumber,
+  'newPassword': instance.newPassword,
+};

--- a/lib/plugins/phone/models/send_otp/send_otp_response.dart
+++ b/lib/plugins/phone/models/send_otp/send_otp_response.dart
@@ -1,0 +1,12 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'send_otp_response.freezed.dart';
+part 'send_otp_response.g.dart';
+
+@freezed
+abstract class SendOTPResponse with _$SendOTPResponse {
+  const factory SendOTPResponse({required String message}) = _SendOTPResponse;
+
+  factory SendOTPResponse.fromJson(Map<String, dynamic> json) =>
+      _$SendOTPResponseFromJson(json);
+}

--- a/lib/plugins/phone/models/send_otp/send_otp_response.freezed.dart
+++ b/lib/plugins/phone/models/send_otp/send_otp_response.freezed.dart
@@ -1,0 +1,148 @@
+// dart format width=80
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'send_otp_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$SendOTPResponse {
+
+ String get message;
+/// Create a copy of SendOTPResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SendOTPResponseCopyWith<SendOTPResponse> get copyWith => _$SendOTPResponseCopyWithImpl<SendOTPResponse>(this as SendOTPResponse, _$identity);
+
+  /// Serializes this SendOTPResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SendOTPResponse&&(identical(other.message, message) || other.message == message));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,message);
+
+@override
+String toString() {
+  return 'SendOTPResponse(message: $message)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SendOTPResponseCopyWith<$Res>  {
+  factory $SendOTPResponseCopyWith(SendOTPResponse value, $Res Function(SendOTPResponse) _then) = _$SendOTPResponseCopyWithImpl;
+@useResult
+$Res call({
+ String message
+});
+
+
+
+
+}
+/// @nodoc
+class _$SendOTPResponseCopyWithImpl<$Res>
+    implements $SendOTPResponseCopyWith<$Res> {
+  _$SendOTPResponseCopyWithImpl(this._self, this._then);
+
+  final SendOTPResponse _self;
+  final $Res Function(SendOTPResponse) _then;
+
+/// Create a copy of SendOTPResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? message = null,}) {
+  return _then(_self.copyWith(
+message: null == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _SendOTPResponse implements SendOTPResponse {
+  const _SendOTPResponse({required this.message});
+  factory _SendOTPResponse.fromJson(Map<String, dynamic> json) => _$SendOTPResponseFromJson(json);
+
+@override final  String message;
+
+/// Create a copy of SendOTPResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$SendOTPResponseCopyWith<_SendOTPResponse> get copyWith => __$SendOTPResponseCopyWithImpl<_SendOTPResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$SendOTPResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SendOTPResponse&&(identical(other.message, message) || other.message == message));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,message);
+
+@override
+String toString() {
+  return 'SendOTPResponse(message: $message)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$SendOTPResponseCopyWith<$Res> implements $SendOTPResponseCopyWith<$Res> {
+  factory _$SendOTPResponseCopyWith(_SendOTPResponse value, $Res Function(_SendOTPResponse) _then) = __$SendOTPResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ String message
+});
+
+
+
+
+}
+/// @nodoc
+class __$SendOTPResponseCopyWithImpl<$Res>
+    implements _$SendOTPResponseCopyWith<$Res> {
+  __$SendOTPResponseCopyWithImpl(this._self, this._then);
+
+  final _SendOTPResponse _self;
+  final $Res Function(_SendOTPResponse) _then;
+
+/// Create a copy of SendOTPResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? message = null,}) {
+  return _then(_SendOTPResponse(
+message: null == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/plugins/phone/models/send_otp/send_otp_response.g.dart
+++ b/lib/plugins/phone/models/send_otp/send_otp_response.g.dart
@@ -1,0 +1,13 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'send_otp_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_SendOTPResponse _$SendOTPResponseFromJson(Map<String, dynamic> json) =>
+    _SendOTPResponse(message: json['message'] as String);
+
+Map<String, dynamic> _$SendOTPResponseToJson(_SendOTPResponse instance) =>
+    <String, dynamic>{'message': instance.message};

--- a/lib/plugins/phone/models/sign_in_phone_body.dart
+++ b/lib/plugins/phone/models/sign_in_phone_body.dart
@@ -5,7 +5,11 @@ part 'sign_in_phone_body.g.dart';
 
 @freezed
 abstract class SignInPhoneBody with _$SignInPhoneBody {
-  const factory SignInPhoneBody() = _SignInPhoneBody;
+  const factory SignInPhoneBody({
+    required String phoneNumber,
+    required String password,
+    bool? rememberMe,
+  }) = _SignInPhoneBody;
 
   factory SignInPhoneBody.fromJson(Map<String, dynamic> json) =>
       _$SignInPhoneBodyFromJson(json);

--- a/lib/plugins/phone/models/sign_in_phone_body.freezed.dart
+++ b/lib/plugins/phone/models/sign_in_phone_body.freezed.dart
@@ -16,7 +16,12 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$SignInPhoneBody {
 
-
+ String get phoneNumber; String get password; bool? get rememberMe;
+/// Create a copy of SignInPhoneBody
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SignInPhoneBodyCopyWith<SignInPhoneBody> get copyWith => _$SignInPhoneBodyCopyWithImpl<SignInPhoneBody>(this as SignInPhoneBody, _$identity);
 
   /// Serializes this SignInPhoneBody to a JSON map.
   Map<String, dynamic> toJson();
@@ -24,24 +29,52 @@ mixin _$SignInPhoneBody {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SignInPhoneBody);
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SignInPhoneBody&&(identical(other.phoneNumber, phoneNumber) || other.phoneNumber == phoneNumber)&&(identical(other.password, password) || other.password == password)&&(identical(other.rememberMe, rememberMe) || other.rememberMe == rememberMe));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => runtimeType.hashCode;
+int get hashCode => Object.hash(runtimeType,phoneNumber,password,rememberMe);
 
 @override
 String toString() {
-  return 'SignInPhoneBody()';
+  return 'SignInPhoneBody(phoneNumber: $phoneNumber, password: $password, rememberMe: $rememberMe)';
 }
 
 
 }
 
 /// @nodoc
-class $SignInPhoneBodyCopyWith<$Res>  {
-$SignInPhoneBodyCopyWith(SignInPhoneBody _, $Res Function(SignInPhoneBody) __);
+abstract mixin class $SignInPhoneBodyCopyWith<$Res>  {
+  factory $SignInPhoneBodyCopyWith(SignInPhoneBody value, $Res Function(SignInPhoneBody) _then) = _$SignInPhoneBodyCopyWithImpl;
+@useResult
+$Res call({
+ String phoneNumber, String password, bool? rememberMe
+});
+
+
+
+
+}
+/// @nodoc
+class _$SignInPhoneBodyCopyWithImpl<$Res>
+    implements $SignInPhoneBodyCopyWith<$Res> {
+  _$SignInPhoneBodyCopyWithImpl(this._self, this._then);
+
+  final SignInPhoneBody _self;
+  final $Res Function(SignInPhoneBody) _then;
+
+/// Create a copy of SignInPhoneBody
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? phoneNumber = null,Object? password = null,Object? rememberMe = freezed,}) {
+  return _then(_self.copyWith(
+phoneNumber: null == phoneNumber ? _self.phoneNumber : phoneNumber // ignore: cast_nullable_to_non_nullable
+as String,password: null == password ? _self.password : password // ignore: cast_nullable_to_non_nullable
+as String,rememberMe: freezed == rememberMe ? _self.rememberMe : rememberMe // ignore: cast_nullable_to_non_nullable
+as bool?,
+  ));
+}
+
 }
 
 
@@ -49,11 +82,18 @@ $SignInPhoneBodyCopyWith(SignInPhoneBody _, $Res Function(SignInPhoneBody) __);
 @JsonSerializable()
 
 class _SignInPhoneBody implements SignInPhoneBody {
-  const _SignInPhoneBody();
+  const _SignInPhoneBody({required this.phoneNumber, required this.password, this.rememberMe});
   factory _SignInPhoneBody.fromJson(Map<String, dynamic> json) => _$SignInPhoneBodyFromJson(json);
 
+@override final  String phoneNumber;
+@override final  String password;
+@override final  bool? rememberMe;
 
-
+/// Create a copy of SignInPhoneBody
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$SignInPhoneBodyCopyWith<_SignInPhoneBody> get copyWith => __$SignInPhoneBodyCopyWithImpl<_SignInPhoneBody>(this, _$identity);
 
 @override
 Map<String, dynamic> toJson() {
@@ -62,22 +102,53 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SignInPhoneBody);
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SignInPhoneBody&&(identical(other.phoneNumber, phoneNumber) || other.phoneNumber == phoneNumber)&&(identical(other.password, password) || other.password == password)&&(identical(other.rememberMe, rememberMe) || other.rememberMe == rememberMe));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => runtimeType.hashCode;
+int get hashCode => Object.hash(runtimeType,phoneNumber,password,rememberMe);
 
 @override
 String toString() {
-  return 'SignInPhoneBody()';
+  return 'SignInPhoneBody(phoneNumber: $phoneNumber, password: $password, rememberMe: $rememberMe)';
 }
 
 
 }
 
+/// @nodoc
+abstract mixin class _$SignInPhoneBodyCopyWith<$Res> implements $SignInPhoneBodyCopyWith<$Res> {
+  factory _$SignInPhoneBodyCopyWith(_SignInPhoneBody value, $Res Function(_SignInPhoneBody) _then) = __$SignInPhoneBodyCopyWithImpl;
+@override @useResult
+$Res call({
+ String phoneNumber, String password, bool? rememberMe
+});
 
 
+
+
+}
+/// @nodoc
+class __$SignInPhoneBodyCopyWithImpl<$Res>
+    implements _$SignInPhoneBodyCopyWith<$Res> {
+  __$SignInPhoneBodyCopyWithImpl(this._self, this._then);
+
+  final _SignInPhoneBody _self;
+  final $Res Function(_SignInPhoneBody) _then;
+
+/// Create a copy of SignInPhoneBody
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? phoneNumber = null,Object? password = null,Object? rememberMe = freezed,}) {
+  return _then(_SignInPhoneBody(
+phoneNumber: null == phoneNumber ? _self.phoneNumber : phoneNumber // ignore: cast_nullable_to_non_nullable
+as String,password: null == password ? _self.password : password // ignore: cast_nullable_to_non_nullable
+as String,rememberMe: freezed == rememberMe ? _self.rememberMe : rememberMe // ignore: cast_nullable_to_non_nullable
+as bool?,
+  ));
+}
+
+
+}
 
 // dart format on

--- a/lib/plugins/phone/models/sign_in_phone_body.g.dart
+++ b/lib/plugins/phone/models/sign_in_phone_body.g.dart
@@ -7,7 +7,15 @@ part of 'sign_in_phone_body.dart';
 // **************************************************************************
 
 _SignInPhoneBody _$SignInPhoneBodyFromJson(Map<String, dynamic> json) =>
-    _SignInPhoneBody();
+    _SignInPhoneBody(
+      phoneNumber: json['phoneNumber'] as String,
+      password: json['password'] as String,
+      rememberMe: json['rememberMe'] as bool?,
+    );
 
 Map<String, dynamic> _$SignInPhoneBodyToJson(_SignInPhoneBody instance) =>
-    <String, dynamic>{};
+    <String, dynamic>{
+      'phoneNumber': instance.phoneNumber,
+      'password': instance.password,
+      'rememberMe': instance.rememberMe,
+    };

--- a/lib/plugins/phone/phone_better_auth.dart
+++ b/lib/plugins/phone/phone_better_auth.dart
@@ -3,14 +3,13 @@ import 'package:retrofit/retrofit.dart';
 
 import '../../core/api/adapter.dart';
 import '../../core/api/default/sign_up/models/sign_up_response/sign_up_response.dart';
-import '../../core/api/models/result/better_error.dart';
 import '../../core/api/models/result/result.dart';
 import '../../core/api/models/result/status_response.dart';
-import '../../core/api/models/session/session_response.dart';
 import 'models/phone_body.dart';
 import 'models/reset/reset_phone_password_body.dart';
 import 'models/sign_in_phone_body.dart';
 import 'models/verify/verify_phone_body.dart';
+import 'models/send_otp/send_otp_response.dart';
 
 part 'phone_better_auth.g.dart';
 
@@ -23,12 +22,12 @@ abstract class PhoneBetterAuth {
   }) = _PhoneBetterAuth;
 
   @POST('/sign-in/phone-number')
-  Future<Result<SessionResponse>> signIn({
+  Future<Result<SignUpResponse>> signIn({
     @Body(nullToAbsent: true) required SignInPhoneBody body,
   });
 
   @POST('/phone-number/send-otp')
-  Future<Result<BetterError>> sendOtp({
+  Future<Result<SendOTPResponse>> sendOtp({
     @Body(nullToAbsent: true) required PhoneBody body,
   });
 

--- a/lib/plugins/phone/phone_better_auth.dart
+++ b/lib/plugins/phone/phone_better_auth.dart
@@ -36,6 +36,11 @@ abstract class PhoneBetterAuth {
     @Body(nullToAbsent: true) required VerifyPhoneBody body,
   });
 
+  @POST('/phone-number/request-password-reset')
+  Future<Result<StatusResponse>> requestPasswordResetOTP({
+    @Body(nullToAbsent: true) required PhoneBody body,
+  });
+
   @POST('/phone-number/reset-password')
   Future<Result<StatusResponse>> restPassword({
     @Body(nullToAbsent: true) required ResetPhonePasswordBody body,

--- a/lib/plugins/phone/phone_better_auth.g.dart
+++ b/lib/plugins/phone/phone_better_auth.g.dart
@@ -125,6 +125,44 @@ class _PhoneBetterAuth implements PhoneBetterAuth {
     );
   }
 
+  Future<HttpResponse<StatusResponse>> _requestPasswordResetOTP({
+    required PhoneBody body,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = body;
+    final _options = _setStreamType<Result<StatusResponse>>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/phone-number/request-password-reset',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late StatusResponse _value;
+    try {
+      _value = StatusResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<Result<StatusResponse>> requestPasswordResetOTP({
+    required PhoneBody body,
+  }) {
+    return BetterAuthCallAdapter<StatusResponse>().adapt(
+      () => _requestPasswordResetOTP(body: body),
+    );
+  }
+
   Future<HttpResponse<StatusResponse>> _restPassword({
     required ResetPhonePasswordBody body,
   }) async {

--- a/lib/plugins/phone/phone_better_auth.g.dart
+++ b/lib/plugins/phone/phone_better_auth.g.dart
@@ -17,14 +17,14 @@ class _PhoneBetterAuth implements PhoneBetterAuth {
 
   final ParseErrorLogger? errorLogger;
 
-  Future<HttpResponse<SessionResponse>> _signIn({
+  Future<HttpResponse<SignUpResponse>> _signIn({
     required SignInPhoneBody body,
   }) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = body;
-    final _options = _setStreamType<Result<SessionResponse>>(
+    final _options = _setStreamType<Result<SignUpResponse>>(
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
@@ -35,9 +35,9 @@ class _PhoneBetterAuth implements PhoneBetterAuth {
           .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
     );
     final _result = await _dio.fetch<Map<String, dynamic>>(_options);
-    late SessionResponse _value;
+    late SignUpResponse _value;
     try {
-      _value = SessionResponse.fromJson(_result.data!);
+      _value = SignUpResponse.fromJson(_result.data!);
     } on Object catch (e, s) {
       errorLogger?.logError(e, s, _options);
       rethrow;
@@ -47,18 +47,20 @@ class _PhoneBetterAuth implements PhoneBetterAuth {
   }
 
   @override
-  Future<Result<SessionResponse>> signIn({required SignInPhoneBody body}) {
-    return BetterAuthCallAdapter<SessionResponse>().adapt(
+  Future<Result<SignUpResponse>> signIn({required SignInPhoneBody body}) {
+    return BetterAuthCallAdapter<SignUpResponse>().adapt(
       () => _signIn(body: body),
     );
   }
 
-  Future<HttpResponse<BetterError>> _sendOtp({required PhoneBody body}) async {
+  Future<HttpResponse<SendOTPResponse>> _sendOtp({
+    required PhoneBody body,
+  }) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = body;
-    final _options = _setStreamType<Result<BetterError>>(
+    final _options = _setStreamType<Result<SendOTPResponse>>(
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
@@ -69,9 +71,9 @@ class _PhoneBetterAuth implements PhoneBetterAuth {
           .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
     );
     final _result = await _dio.fetch<Map<String, dynamic>>(_options);
-    late BetterError _value;
+    late SendOTPResponse _value;
     try {
-      _value = BetterError.fromJson(_result.data!);
+      _value = SendOTPResponse.fromJson(_result.data!);
     } on Object catch (e, s) {
       errorLogger?.logError(e, s, _options);
       rethrow;
@@ -81,8 +83,8 @@ class _PhoneBetterAuth implements PhoneBetterAuth {
   }
 
   @override
-  Future<Result<BetterError>> sendOtp({required PhoneBody body}) {
-    return BetterAuthCallAdapter<BetterError>().adapt(
+  Future<Result<SendOTPResponse>> sendOtp({required PhoneBody body}) {
+    return BetterAuthCallAdapter<SendOTPResponse>().adapt(
       () => _sendOtp(body: body),
     );
   }

--- a/lib/plugins/phone/phone_plugin.dart
+++ b/lib/plugins/phone/phone_plugin.dart
@@ -4,3 +4,4 @@ export 'models/phone_body.dart';
 export 'models/sign_in_phone_body.dart';
 export 'models/verify/verify_phone_body.dart';
 export 'models/reset/reset_phone_password_body.dart';
+export 'models/send_otp/send_otp_response.dart';


### PR DESCRIPTION
1. Added SuccessResponse model to standardize success responses across API calls.
2. Added SendOTPResponse model to handle OTP sending responses correctly.
3. Updated api's to use proper models for responses:
  - `signIn.anonymous` now returns `SignUpResponse`.
  - `sinIn.phoneNumber` now returns `SignUpResponse`
  - `deleteUser` now returns `SuccessResponse`.
  - `admin.removeUser` now returns `SuccessResponse`.
  - `admin.removeUserSessions` now returns `SuccessResponse`.
  - `emailOtp.sendVerification` now returns `SuccessResponse`.
  - `emailOtp.forgotPassword` now returns `SuccessResponse`.
  - `emailOtp.resetPassword` now returns `SuccessResponse`.
  - `phoneNumber.resetPassword` now returns `SignUpResponse`.
  - `phoneNumber.sendOtp` now returns `SendOTPResponse`.