### PR TITLE
feat: Support Better Auth additionalFields on users & sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ passkeys, API keys, admin, phone, email-OTP, JWT, one-time-token, anonymous).
 - [Working with `Result`](#working-with-result)
 - [Session & auth state](#session--auth-state)
 - [Email & password](#email--password)
+- [Additional fields](#additional-fields-custom-user--session-data)
 - [Username](#username)
 - [Anonymous](#anonymous)
 - [Social / OAuth](#social--oauth) · [redirect](#redirect-flow-github-etc) · [idToken (Google)](#idtoken-flow-google-native)
@@ -209,6 +210,68 @@ await client.changeEmail(newEmail: 'new@mail.com');
 // Delete account
 await client.deleteUser(password: '12345678');
 ```
+
+## Additional fields (custom user & session data)
+
+Better Auth lets you add custom columns to the `user` and `session` tables via
+[`additionalFields`](https://www.better-auth.com/docs/concepts/database#extending-core-schema).
+The server merges them as flat top-level keys into the `user`/`session` JSON, so
+this client collects every key the static models don't own into an
+`additionalFields` map rather than dropping it.
+
+### Reading custom fields
+
+`User` and `Session` expose an `additionalFields` map and a typed `field<T>()`
+accessor:
+
+```dart
+final res = await client.getSession();
+final user = res.data!.user!;
+final session = res.data!.session!;
+
+user.additionalFields['firstName'];        // dynamic
+user.field<String>('firstName');           // typed, or null if absent
+user.field<String>('role') ?? 'user';      // with a default
+session.field<String>('theme');            // session custom fields too
+```
+
+For fields you read often, add your own extension so call sites stay typo-safe
+and your server schema is the single source of truth:
+
+```dart
+extension MyUserFields on User {
+  String? get firstName => field('firstName');
+  String get role => field<String>('role') ?? 'user';
+}
+```
+
+> A field declared with `returned: false` on the server is stripped from the
+> response before it reaches the client, so it can't be read here — that's a
+> server-side setting, not a client limitation.
+
+### Writing custom fields
+
+Pass `additionalFields` to sign-up / update calls. Entries are flat-merged into
+the request body as top-level keys (Better Auth's wire format), so the example
+below sends `firstName`/`lastName` next to `name`/`email`/`password`:
+
+```dart
+await client.signUp.email(
+  name: 'Jane Doe',
+  email: 'j@x.io',
+  password: '12345678',
+  additionalFields: {'firstName': 'Jane', 'lastName': 'Doe'},
+);
+
+await client.updateUser(
+  additionalFields: {'firstName': 'Jane', 'lang': 'fr'},
+);
+```
+
+`signIn.email(...)` and `signIn.username(...)` accept `additionalFields` too.
+For full control over the body (e.g. nested values), use the raw variants
+`emailRaw` / `usernameRaw` on the sign-in/up clients and `updateUserRaw` — the
+same convention as the organization plugin's `*Raw` methods.
 
 ## Username
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -188,7 +188,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.6"
+    version: "0.6.2"
   flutter_dotenv:
     dependency: "direct main"
     description:
@@ -349,7 +349,7 @@ packages:
     source: hosted
     version: "3.1.0"
   google_sign_in_web:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: google_sign_in_web
       sha256: d473003eeca892f96a01a64fc803378be765071cb0c265ee872c7f8683245d14
@@ -488,10 +488,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -661,10 +661,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   theme_extensions_builder_annotation:
     dependency: transitive
     description:

--- a/lib/core/api/better_auth_client.dart
+++ b/lib/core/api/better_auth_client.dart
@@ -68,10 +68,11 @@ abstract class BetterAuthClient {
     @BodyExtra('revokeOtherSessions') bool? revokeOtherSessions,
   });
 
+  /// Raw `POST /update-user` body. Prefer the typed `updateUser` extension,
+  /// which builds this map and flat-merges `additionalFields`.
   @POST('/update-user')
-  Future<Result<UserWrapperResponse>> updateUser({
-    @BodyExtra('name') String? name,
-    @BodyExtra('image') String? image,
+  Future<Result<UserWrapperResponse>> updateUserRaw({
+    @Body(nullToAbsent: true) required Map<String, dynamic> body,
   });
 
   @POST('/delete-user')

--- a/lib/core/api/better_auth_client.g.dart
+++ b/lib/core/api/better_auth_client.g.dart
@@ -360,15 +360,14 @@ class _BetterAuthClient implements BetterAuthClient {
     );
   }
 
-  Future<HttpResponse<UserWrapperResponse>> _updateUser({
-    String? name,
-    String? image,
+  Future<HttpResponse<UserWrapperResponse>> _updateUserRaw({
+    required Map<String, dynamic> body,
   }) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
-    queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
-    final _data = <String, dynamic>{'name': name, 'image': image};
+    final _data = <String, dynamic>{};
+    _data.addAll(body);
     _data.removeWhere((k, v) => v == null);
     final _options = _setStreamType<Result<UserWrapperResponse>>(
       Options(method: 'POST', headers: _headers, extra: _extra)
@@ -393,12 +392,11 @@ class _BetterAuthClient implements BetterAuthClient {
   }
 
   @override
-  Future<Result<UserWrapperResponse>> updateUser({
-    String? name,
-    String? image,
+  Future<Result<UserWrapperResponse>> updateUserRaw({
+    required Map<String, dynamic> body,
   }) {
     return BetterAuthCallAdapter<UserWrapperResponse>().adapt(
-      () => _updateUser(name: name, image: image),
+      () => _updateUserRaw(body: body),
     );
   }
 

--- a/lib/core/api/better_auth_client_extension.dart
+++ b/lib/core/api/better_auth_client_extension.dart
@@ -13,10 +13,11 @@ extension UpdateUserBetterAuth on BetterAuthClient {
     Map<String, dynamic>? additionalFields,
   }) =>
       updateUserRaw(
+        // Spread first so the typed fields below win on key collision.
         body: {
+          ...?additionalFields,
           'name': ?name,
           'image': ?image,
-          ...?additionalFields,
         },
       );
 }

--- a/lib/core/api/better_auth_client_extension.dart
+++ b/lib/core/api/better_auth_client_extension.dart
@@ -1,0 +1,22 @@
+import 'better_auth_client.dart';
+import 'models/common/user_wrapper/user_wrapper_response.dart';
+import 'models/result/result.dart';
+
+/// Typed `POST /update-user`. [additionalFields] are flat-merged into the body
+/// — Better Auth accepts custom user fields
+/// ([`additionalFields`](https://www.better-auth.com/docs/concepts/database#extending-core-schema))
+/// as top-level keys alongside `name`/`image`.
+extension UpdateUserBetterAuth on BetterAuthClient {
+  Future<Result<UserWrapperResponse>> updateUser({
+    String? name,
+    String? image,
+    Map<String, dynamic>? additionalFields,
+  }) =>
+      updateUserRaw(
+        body: {
+          'name': ?name,
+          'image': ?image,
+          ...?additionalFields,
+        },
+      );
+}

--- a/lib/core/api/default/sign_in/sign_in_better_auth.dart
+++ b/lib/core/api/default/sign_in/sign_in_better_auth.dart
@@ -32,19 +32,16 @@ abstract class SignInBetterAuth {
     @BodyExtra('loginHint') String? loginHint,
   });
 
+  /// Raw `POST /sign-in/email` body. Prefer the typed `email` extension.
   @POST('/sign-in/email')
-  Future<Result<SignInEmailResponse>> email({
-    @BodyExtra('email') required String email,
-    @BodyExtra('password') required String password,
-    @BodyExtra('callbackURL') String? callbackURL,
-    @BodyExtra('rememberMe') bool? rememberMe,
+  Future<Result<SignInEmailResponse>> emailRaw({
+    @Body(nullToAbsent: true) required Map<String, dynamic> body,
   });
 
+  /// Raw `POST /sign-in/username` body. Prefer the typed `username` extension.
   @POST('/sign-in/username')
-  Future<Result<SignInEmailResponse>> username({
-    @BodyExtra('username') required String username,
-    @BodyExtra('password') required String password,
-    @BodyExtra('rememberMe') bool? rememberMe,
+  Future<Result<SignInEmailResponse>> usernameRaw({
+    @Body(nullToAbsent: true) required Map<String, dynamic> body,
   });
 
   /// Better Auth [`anonymous`](https://www.better-auth.com/docs/plugins/anonymous) plugin.

--- a/lib/core/api/default/sign_in/sign_in_better_auth.g.dart
+++ b/lib/core/api/default/sign_in/sign_in_better_auth.g.dart
@@ -95,22 +95,14 @@ class _SignInBetterAuth implements SignInBetterAuth {
     );
   }
 
-  Future<HttpResponse<SignInEmailResponse>> _email({
-    required String email,
-    required String password,
-    String? callbackURL,
-    bool? rememberMe,
+  Future<HttpResponse<SignInEmailResponse>> _emailRaw({
+    required Map<String, dynamic> body,
   }) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
-    queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
-    final _data = <String, dynamic>{
-      'email': email,
-      'password': password,
-      'callbackURL': callbackURL,
-      'rememberMe': rememberMe,
-    };
+    final _data = <String, dynamic>{};
+    _data.addAll(body);
     _data.removeWhere((k, v) => v == null);
     final _options = _setStreamType<Result<SignInEmailResponse>>(
       Options(method: 'POST', headers: _headers, extra: _extra)
@@ -135,36 +127,22 @@ class _SignInBetterAuth implements SignInBetterAuth {
   }
 
   @override
-  Future<Result<SignInEmailResponse>> email({
-    required String email,
-    required String password,
-    String? callbackURL,
-    bool? rememberMe,
+  Future<Result<SignInEmailResponse>> emailRaw({
+    required Map<String, dynamic> body,
   }) {
     return BetterAuthCallAdapter<SignInEmailResponse>().adapt(
-      () => _email(
-        email: email,
-        password: password,
-        callbackURL: callbackURL,
-        rememberMe: rememberMe,
-      ),
+      () => _emailRaw(body: body),
     );
   }
 
-  Future<HttpResponse<SignInEmailResponse>> _username({
-    required String username,
-    required String password,
-    bool? rememberMe,
+  Future<HttpResponse<SignInEmailResponse>> _usernameRaw({
+    required Map<String, dynamic> body,
   }) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
-    queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
-    final _data = <String, dynamic>{
-      'username': username,
-      'password': password,
-      'rememberMe': rememberMe,
-    };
+    final _data = <String, dynamic>{};
+    _data.addAll(body);
     _data.removeWhere((k, v) => v == null);
     final _options = _setStreamType<Result<SignInEmailResponse>>(
       Options(method: 'POST', headers: _headers, extra: _extra)
@@ -189,17 +167,11 @@ class _SignInBetterAuth implements SignInBetterAuth {
   }
 
   @override
-  Future<Result<SignInEmailResponse>> username({
-    required String username,
-    required String password,
-    bool? rememberMe,
+  Future<Result<SignInEmailResponse>> usernameRaw({
+    required Map<String, dynamic> body,
   }) {
     return BetterAuthCallAdapter<SignInEmailResponse>().adapt(
-      () => _username(
-        username: username,
-        password: password,
-        rememberMe: rememberMe,
-      ),
+      () => _usernameRaw(body: body),
     );
   }
 

--- a/lib/core/api/default/sign_in/sign_in_extension.dart
+++ b/lib/core/api/default/sign_in/sign_in_extension.dart
@@ -11,6 +11,7 @@ import '../../models/result/better_error.dart';
 import '../../models/result/result.dart';
 import '../../web_redirect.dart';
 import '../social/social_extension.dart';
+import 'models/email/sign_in_email_response.dart';
 import 'models/social/sign_in_social_response.dart';
 import 'models/social/social_id_token_body.dart';
 import 'sign_in_better_auth.dart';
@@ -288,4 +289,42 @@ String? _extractSchemeFromUrl(String? url) {
     return null;
   }
   return parsed.scheme;
+}
+
+/// Typed `POST /sign-in/email` and `/sign-in/username`. [additionalFields]
+/// are flat-merged into the body — Better Auth accepts custom user fields
+/// ([`additionalFields`](https://www.better-auth.com/docs/concepts/database#extending-core-schema))
+/// as top-level keys.
+extension SignInEmailBetterAuth on SignInBetterAuth {
+  Future<Result<SignInEmailResponse>> email({
+    required String email,
+    required String password,
+    String? callbackURL,
+    bool? rememberMe,
+    Map<String, dynamic>? additionalFields,
+  }) =>
+      emailRaw(
+        body: {
+          'email': email,
+          'password': password,
+          'callbackURL': ?callbackURL,
+          'rememberMe': ?rememberMe,
+          ...?additionalFields,
+        },
+      );
+
+  Future<Result<SignInEmailResponse>> username({
+    required String username,
+    required String password,
+    bool? rememberMe,
+    Map<String, dynamic>? additionalFields,
+  }) =>
+      usernameRaw(
+        body: {
+          'username': username,
+          'password': password,
+          'rememberMe': ?rememberMe,
+          ...?additionalFields,
+        },
+      );
 }

--- a/lib/core/api/default/sign_in/sign_in_extension.dart
+++ b/lib/core/api/default/sign_in/sign_in_extension.dart
@@ -304,12 +304,13 @@ extension SignInEmailBetterAuth on SignInBetterAuth {
     Map<String, dynamic>? additionalFields,
   }) =>
       emailRaw(
+        // Spread first so the typed fields below win on key collision.
         body: {
+          ...?additionalFields,
           'email': email,
           'password': password,
           'callbackURL': ?callbackURL,
           'rememberMe': ?rememberMe,
-          ...?additionalFields,
         },
       );
 
@@ -320,11 +321,12 @@ extension SignInEmailBetterAuth on SignInBetterAuth {
     Map<String, dynamic>? additionalFields,
   }) =>
       usernameRaw(
+        // Spread first so the typed fields below win on key collision.
         body: {
+          ...?additionalFields,
           'username': username,
           'password': password,
           'rememberMe': ?rememberMe,
-          ...?additionalFields,
         },
       );
 }

--- a/lib/core/api/default/sign_up/sign_up_better_auth.dart
+++ b/lib/core/api/default/sign_up/sign_up_better_auth.dart
@@ -15,11 +15,10 @@ abstract class SignUpBetterAuth {
     ParseErrorLogger? errorLogger,
   }) = _SignUpBetterAuth;
 
+  /// Raw `POST /sign-up/email` body. Prefer the typed `email` extension on
+  /// [SignUpBetterAuth], which builds this map and flat-merges `additionalFields`.
   @POST('/sign-up/email')
-  Future<Result<SignUpResponse>> email({
-    @BodyExtra('name') required String name,
-    @BodyExtra('email') required String email,
-    @BodyExtra('password') required String password,
-    @BodyExtra('callbackURL') String? callbackURL,
+  Future<Result<SignUpResponse>> emailRaw({
+    @Body(nullToAbsent: true) required Map<String, dynamic> body,
   });
 }

--- a/lib/core/api/default/sign_up/sign_up_better_auth.g.dart
+++ b/lib/core/api/default/sign_up/sign_up_better_auth.g.dart
@@ -19,22 +19,14 @@ class _SignUpBetterAuth implements SignUpBetterAuth {
 
   final ParseErrorLogger? errorLogger;
 
-  Future<HttpResponse<SignUpResponse>> _email({
-    required String name,
-    required String email,
-    required String password,
-    String? callbackURL,
+  Future<HttpResponse<SignUpResponse>> _emailRaw({
+    required Map<String, dynamic> body,
   }) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
-    queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
-    final _data = <String, dynamic>{
-      'name': name,
-      'email': email,
-      'password': password,
-      'callbackURL': callbackURL,
-    };
+    final _data = <String, dynamic>{};
+    _data.addAll(body);
     _data.removeWhere((k, v) => v == null);
     final _options = _setStreamType<Result<SignUpResponse>>(
       Options(method: 'POST', headers: _headers, extra: _extra)
@@ -59,19 +51,11 @@ class _SignUpBetterAuth implements SignUpBetterAuth {
   }
 
   @override
-  Future<Result<SignUpResponse>> email({
-    required String name,
-    required String email,
-    required String password,
-    String? callbackURL,
+  Future<Result<SignUpResponse>> emailRaw({
+    required Map<String, dynamic> body,
   }) {
     return BetterAuthCallAdapter<SignUpResponse>().adapt(
-      () => _email(
-        name: name,
-        email: email,
-        password: password,
-        callbackURL: callbackURL,
-      ),
+      () => _emailRaw(body: body),
     );
   }
 

--- a/lib/core/api/default/sign_up/sign_up_extension.dart
+++ b/lib/core/api/default/sign_up/sign_up_extension.dart
@@ -24,12 +24,13 @@ extension SignUpEmailBetterAuth on SignUpBetterAuth {
     Map<String, dynamic>? additionalFields,
   }) =>
       emailRaw(
+        // Spread first so the typed fields below win on key collision.
         body: {
+          ...?additionalFields,
           'name': name,
           'email': email,
           'password': password,
           'callbackURL': ?callbackURL,
-          ...?additionalFields,
         },
       );
 }

--- a/lib/core/api/default/sign_up/sign_up_extension.dart
+++ b/lib/core/api/default/sign_up/sign_up_extension.dart
@@ -1,5 +1,7 @@
 import '../../../flutter_better_auth.dart';
 import '../../better_auth_client.dart';
+import '../../models/result/result.dart';
+import 'models/sign_up_response/sign_up_response.dart';
 import 'sign_up_better_auth.dart';
 
 extension SignUpBetterAuthExtension on BetterAuthClient {
@@ -7,4 +9,27 @@ extension SignUpBetterAuthExtension on BetterAuthClient {
     FlutterBetterAuth.dioClient,
     baseUrl: FlutterBetterAuth.baseUrl,
   );
+}
+
+/// Typed `POST /sign-up/email`. [additionalFields] are flat-merged into the
+/// body — Better Auth accepts custom user fields
+/// ([`additionalFields`](https://www.better-auth.com/docs/concepts/database#extending-core-schema))
+/// as top-level keys alongside `name`/`email`/`password`.
+extension SignUpEmailBetterAuth on SignUpBetterAuth {
+  Future<Result<SignUpResponse>> email({
+    required String name,
+    required String email,
+    required String password,
+    String? callbackURL,
+    Map<String, dynamic>? additionalFields,
+  }) =>
+      emailRaw(
+        body: {
+          'name': name,
+          'email': email,
+          'password': password,
+          'callbackURL': ?callbackURL,
+          ...?additionalFields,
+        },
+      );
 }

--- a/lib/core/models/additional_fields.dart
+++ b/lib/core/models/additional_fields.dart
@@ -1,0 +1,46 @@
+import 'session/session.dart';
+import 'user/user.dart';
+
+/// Reads an [User.additionalFields] / [Session.additionalFields] entry with a
+/// typed cast. Returns `null` when [key] is absent; throws an [ArgumentError]
+/// when the key exists but the value isn't assignable to [T]. Pass [decode] for
+/// values that need conversion (e.g. nested JSON into a typed object).
+T? _readAdditionalField<T>(
+  Map<String, dynamic> fields,
+  String key, {
+  T Function(Object? value)? decode,
+}) {
+  if (!fields.containsKey(key)) return null;
+  final value = decode != null ? decode(fields[key]) : fields[key];
+  if (value is T) return value;
+  throw ArgumentError.value(value, key, 'additional field is not of type $T');
+}
+
+/// Typed access to Better Auth [`user.additionalFields`](https://www.better-auth.com/docs/concepts/database#extending-core-schema).
+///
+/// For fields you read often, add your own extension in app code so call sites
+/// stay typo-safe:
+/// ```dart
+/// extension MyUserFields on User {
+///   String? get firstName => field('firstName');
+///   String get role => field<String>('role') ?? 'user';
+/// }
+/// ```
+extension UserAdditionalFields on User {
+  /// Reads [key] from [User.additionalFields], casting to [T].
+  ///
+  /// Returns `null` for an absent key. Throws if the key exists but its value
+  /// is not assignable to [T] (e.g. asking for `int` on a string field).
+  T? field<T>(String key, {T Function(Object? value)? decode}) =>
+      _readAdditionalField(additionalFields, key, decode: decode);
+}
+
+/// Typed access to Better Auth [`session.additionalFields`](https://www.better-auth.com/docs/concepts/database#extending-core-schema).
+extension SessionAdditionalFields on Session {
+  /// Reads [key] from [Session.additionalFields], casting to [T].
+  ///
+  /// Returns `null` for an absent key. Throws if the key exists but its value
+  /// is not assignable to [T].
+  T? field<T>(String key, {T Function(Object? value)? decode}) =>
+      _readAdditionalField(additionalFields, key, decode: decode);
+}

--- a/lib/core/models/session/session.dart
+++ b/lib/core/models/session/session.dart
@@ -20,8 +20,41 @@ abstract class Session with _$Session {
     /// Present when Better Auth [`organization`](https://www.better-auth.com/docs/plugins/organization)
     /// is configured with `teams.enabled`.
     String? activeTeamId,
+
+    /// Server-defined custom fields ([`additionalFields`](https://www.better-auth.com/docs/concepts/database#extending-core-schema))
+    /// that aren't part of the static [Session] shape. Populated from unmapped
+    /// JSON keys by [Session.fromJson]; never serialized back out. Read via the
+    /// `field` extension, e.g. `session.field<String>('theme')`.
+    @JsonKey(readValue: _readSessionAdditionalFields, includeToJson: false)
+    @Default(<String, dynamic>{})
+    Map<String, dynamic> additionalFields,
   }) = _Session;
 
-  factory Session.fromJson(Map<String, dynamic> json) =>
-      _$SessionFromJson(json);
+  factory Session.fromJson(Map<String, dynamic> json) => _$SessionFromJson(json);
+}
+
+const _knownSessionKeys = <String>{
+  'id',
+  'token',
+  'expiresAt',
+  'createdAt',
+  'updatedAt',
+  'ipAddress',
+  'userAgent',
+  'userId',
+  'impersonatedBy',
+  'activeOrganizationId',
+  'activeTeamId',
+};
+
+/// [JsonKey.readValue] for [Session.additionalFields]: returns every server key
+/// the static model doesn't own — Better Auth merges `additionalFields` into
+/// the session object as flat top-level keys, so this collects the remainder.
+Map<String, dynamic> _readSessionAdditionalFields(
+  Map<dynamic, dynamic> json,
+  String _,
+) {
+  final extra = Map<String, dynamic>.from(json)
+    ..removeWhere((key, _) => _knownSessionKeys.contains(key));
+  return Map.unmodifiable(extra);
 }

--- a/lib/core/models/session/session.freezed.dart
+++ b/lib/core/models/session/session.freezed.dart
@@ -17,7 +17,11 @@ mixin _$Session {
 
  String get id; String get token; DateTime get expiresAt; DateTime? get createdAt; DateTime? get updatedAt; String? get ipAddress; String? get userAgent; String get userId; String? get impersonatedBy; String? get activeOrganizationId;/// Present when Better Auth [`organization`](https://www.better-auth.com/docs/plugins/organization)
 /// is configured with `teams.enabled`.
- String? get activeTeamId;
+ String? get activeTeamId;/// Server-defined custom fields ([`additionalFields`](https://www.better-auth.com/docs/concepts/database#extending-core-schema))
+/// that aren't part of the static [Session] shape. Populated from unmapped
+/// JSON keys by [Session.fromJson]; never serialized back out. Read via the
+/// `field` extension, e.g. `session.field<String>('theme')`.
+@JsonKey(readValue: _readSessionAdditionalFields, includeToJson: false) Map<String, dynamic> get additionalFields;
 /// Create a copy of Session
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -30,16 +34,16 @@ $SessionCopyWith<Session> get copyWith => _$SessionCopyWithImpl<Session>(this as
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is Session&&(identical(other.id, id) || other.id == id)&&(identical(other.token, token) || other.token == token)&&(identical(other.expiresAt, expiresAt) || other.expiresAt == expiresAt)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.ipAddress, ipAddress) || other.ipAddress == ipAddress)&&(identical(other.userAgent, userAgent) || other.userAgent == userAgent)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.impersonatedBy, impersonatedBy) || other.impersonatedBy == impersonatedBy)&&(identical(other.activeOrganizationId, activeOrganizationId) || other.activeOrganizationId == activeOrganizationId)&&(identical(other.activeTeamId, activeTeamId) || other.activeTeamId == activeTeamId));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Session&&(identical(other.id, id) || other.id == id)&&(identical(other.token, token) || other.token == token)&&(identical(other.expiresAt, expiresAt) || other.expiresAt == expiresAt)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.ipAddress, ipAddress) || other.ipAddress == ipAddress)&&(identical(other.userAgent, userAgent) || other.userAgent == userAgent)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.impersonatedBy, impersonatedBy) || other.impersonatedBy == impersonatedBy)&&(identical(other.activeOrganizationId, activeOrganizationId) || other.activeOrganizationId == activeOrganizationId)&&(identical(other.activeTeamId, activeTeamId) || other.activeTeamId == activeTeamId)&&const DeepCollectionEquality().equals(other.additionalFields, additionalFields));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,token,expiresAt,createdAt,updatedAt,ipAddress,userAgent,userId,impersonatedBy,activeOrganizationId,activeTeamId);
+int get hashCode => Object.hash(runtimeType,id,token,expiresAt,createdAt,updatedAt,ipAddress,userAgent,userId,impersonatedBy,activeOrganizationId,activeTeamId,const DeepCollectionEquality().hash(additionalFields));
 
 @override
 String toString() {
-  return 'Session(id: $id, token: $token, expiresAt: $expiresAt, createdAt: $createdAt, updatedAt: $updatedAt, ipAddress: $ipAddress, userAgent: $userAgent, userId: $userId, impersonatedBy: $impersonatedBy, activeOrganizationId: $activeOrganizationId, activeTeamId: $activeTeamId)';
+  return 'Session(id: $id, token: $token, expiresAt: $expiresAt, createdAt: $createdAt, updatedAt: $updatedAt, ipAddress: $ipAddress, userAgent: $userAgent, userId: $userId, impersonatedBy: $impersonatedBy, activeOrganizationId: $activeOrganizationId, activeTeamId: $activeTeamId, additionalFields: $additionalFields)';
 }
 
 
@@ -50,7 +54,7 @@ abstract mixin class $SessionCopyWith<$Res>  {
   factory $SessionCopyWith(Session value, $Res Function(Session) _then) = _$SessionCopyWithImpl;
 @useResult
 $Res call({
- String id, String token, DateTime expiresAt, DateTime? createdAt, DateTime? updatedAt, String? ipAddress, String? userAgent, String userId, String? impersonatedBy, String? activeOrganizationId, String? activeTeamId
+ String id, String token, DateTime expiresAt, DateTime? createdAt, DateTime? updatedAt, String? ipAddress, String? userAgent, String userId, String? impersonatedBy, String? activeOrganizationId, String? activeTeamId,@JsonKey(readValue: _readSessionAdditionalFields, includeToJson: false) Map<String, dynamic> additionalFields
 });
 
 
@@ -67,7 +71,7 @@ class _$SessionCopyWithImpl<$Res>
 
 /// Create a copy of Session
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? token = null,Object? expiresAt = null,Object? createdAt = freezed,Object? updatedAt = freezed,Object? ipAddress = freezed,Object? userAgent = freezed,Object? userId = null,Object? impersonatedBy = freezed,Object? activeOrganizationId = freezed,Object? activeTeamId = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? token = null,Object? expiresAt = null,Object? createdAt = freezed,Object? updatedAt = freezed,Object? ipAddress = freezed,Object? userAgent = freezed,Object? userId = null,Object? impersonatedBy = freezed,Object? activeOrganizationId = freezed,Object? activeTeamId = freezed,Object? additionalFields = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,token: null == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
@@ -80,7 +84,8 @@ as String?,userId: null == userId ? _self.userId : userId // ignore: cast_nullab
 as String,impersonatedBy: freezed == impersonatedBy ? _self.impersonatedBy : impersonatedBy // ignore: cast_nullable_to_non_nullable
 as String?,activeOrganizationId: freezed == activeOrganizationId ? _self.activeOrganizationId : activeOrganizationId // ignore: cast_nullable_to_non_nullable
 as String?,activeTeamId: freezed == activeTeamId ? _self.activeTeamId : activeTeamId // ignore: cast_nullable_to_non_nullable
-as String?,
+as String?,additionalFields: null == additionalFields ? _self.additionalFields : additionalFields // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>,
   ));
 }
 
@@ -165,10 +170,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String token,  DateTime expiresAt,  DateTime? createdAt,  DateTime? updatedAt,  String? ipAddress,  String? userAgent,  String userId,  String? impersonatedBy,  String? activeOrganizationId,  String? activeTeamId)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String token,  DateTime expiresAt,  DateTime? createdAt,  DateTime? updatedAt,  String? ipAddress,  String? userAgent,  String userId,  String? impersonatedBy,  String? activeOrganizationId,  String? activeTeamId, @JsonKey(readValue: _readSessionAdditionalFields, includeToJson: false)  Map<String, dynamic> additionalFields)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _Session() when $default != null:
-return $default(_that.id,_that.token,_that.expiresAt,_that.createdAt,_that.updatedAt,_that.ipAddress,_that.userAgent,_that.userId,_that.impersonatedBy,_that.activeOrganizationId,_that.activeTeamId);case _:
+return $default(_that.id,_that.token,_that.expiresAt,_that.createdAt,_that.updatedAt,_that.ipAddress,_that.userAgent,_that.userId,_that.impersonatedBy,_that.activeOrganizationId,_that.activeTeamId,_that.additionalFields);case _:
   return orElse();
 
 }
@@ -186,10 +191,10 @@ return $default(_that.id,_that.token,_that.expiresAt,_that.createdAt,_that.updat
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String token,  DateTime expiresAt,  DateTime? createdAt,  DateTime? updatedAt,  String? ipAddress,  String? userAgent,  String userId,  String? impersonatedBy,  String? activeOrganizationId,  String? activeTeamId)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String token,  DateTime expiresAt,  DateTime? createdAt,  DateTime? updatedAt,  String? ipAddress,  String? userAgent,  String userId,  String? impersonatedBy,  String? activeOrganizationId,  String? activeTeamId, @JsonKey(readValue: _readSessionAdditionalFields, includeToJson: false)  Map<String, dynamic> additionalFields)  $default,) {final _that = this;
 switch (_that) {
 case _Session():
-return $default(_that.id,_that.token,_that.expiresAt,_that.createdAt,_that.updatedAt,_that.ipAddress,_that.userAgent,_that.userId,_that.impersonatedBy,_that.activeOrganizationId,_that.activeTeamId);case _:
+return $default(_that.id,_that.token,_that.expiresAt,_that.createdAt,_that.updatedAt,_that.ipAddress,_that.userAgent,_that.userId,_that.impersonatedBy,_that.activeOrganizationId,_that.activeTeamId,_that.additionalFields);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -206,10 +211,10 @@ return $default(_that.id,_that.token,_that.expiresAt,_that.createdAt,_that.updat
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String token,  DateTime expiresAt,  DateTime? createdAt,  DateTime? updatedAt,  String? ipAddress,  String? userAgent,  String userId,  String? impersonatedBy,  String? activeOrganizationId,  String? activeTeamId)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String token,  DateTime expiresAt,  DateTime? createdAt,  DateTime? updatedAt,  String? ipAddress,  String? userAgent,  String userId,  String? impersonatedBy,  String? activeOrganizationId,  String? activeTeamId, @JsonKey(readValue: _readSessionAdditionalFields, includeToJson: false)  Map<String, dynamic> additionalFields)?  $default,) {final _that = this;
 switch (_that) {
 case _Session() when $default != null:
-return $default(_that.id,_that.token,_that.expiresAt,_that.createdAt,_that.updatedAt,_that.ipAddress,_that.userAgent,_that.userId,_that.impersonatedBy,_that.activeOrganizationId,_that.activeTeamId);case _:
+return $default(_that.id,_that.token,_that.expiresAt,_that.createdAt,_that.updatedAt,_that.ipAddress,_that.userAgent,_that.userId,_that.impersonatedBy,_that.activeOrganizationId,_that.activeTeamId,_that.additionalFields);case _:
   return null;
 
 }
@@ -221,7 +226,7 @@ return $default(_that.id,_that.token,_that.expiresAt,_that.createdAt,_that.updat
 @JsonSerializable()
 
 class _Session implements Session {
-  const _Session({required this.id, required this.token, required this.expiresAt, this.createdAt, this.updatedAt, this.ipAddress, this.userAgent, required this.userId, this.impersonatedBy, this.activeOrganizationId, this.activeTeamId});
+  const _Session({required this.id, required this.token, required this.expiresAt, this.createdAt, this.updatedAt, this.ipAddress, this.userAgent, required this.userId, this.impersonatedBy, this.activeOrganizationId, this.activeTeamId, @JsonKey(readValue: _readSessionAdditionalFields, includeToJson: false) final  Map<String, dynamic> additionalFields = const <String, dynamic>{}}): _additionalFields = additionalFields;
   factory _Session.fromJson(Map<String, dynamic> json) => _$SessionFromJson(json);
 
 @override final  String id;
@@ -237,6 +242,21 @@ class _Session implements Session {
 /// Present when Better Auth [`organization`](https://www.better-auth.com/docs/plugins/organization)
 /// is configured with `teams.enabled`.
 @override final  String? activeTeamId;
+/// Server-defined custom fields ([`additionalFields`](https://www.better-auth.com/docs/concepts/database#extending-core-schema))
+/// that aren't part of the static [Session] shape. Populated from unmapped
+/// JSON keys by [Session.fromJson]; never serialized back out. Read via the
+/// `field` extension, e.g. `session.field<String>('theme')`.
+ final  Map<String, dynamic> _additionalFields;
+/// Server-defined custom fields ([`additionalFields`](https://www.better-auth.com/docs/concepts/database#extending-core-schema))
+/// that aren't part of the static [Session] shape. Populated from unmapped
+/// JSON keys by [Session.fromJson]; never serialized back out. Read via the
+/// `field` extension, e.g. `session.field<String>('theme')`.
+@override@JsonKey(readValue: _readSessionAdditionalFields, includeToJson: false) Map<String, dynamic> get additionalFields {
+  if (_additionalFields is EqualUnmodifiableMapView) return _additionalFields;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(_additionalFields);
+}
+
 
 /// Create a copy of Session
 /// with the given fields replaced by the non-null parameter values.
@@ -251,16 +271,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Session&&(identical(other.id, id) || other.id == id)&&(identical(other.token, token) || other.token == token)&&(identical(other.expiresAt, expiresAt) || other.expiresAt == expiresAt)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.ipAddress, ipAddress) || other.ipAddress == ipAddress)&&(identical(other.userAgent, userAgent) || other.userAgent == userAgent)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.impersonatedBy, impersonatedBy) || other.impersonatedBy == impersonatedBy)&&(identical(other.activeOrganizationId, activeOrganizationId) || other.activeOrganizationId == activeOrganizationId)&&(identical(other.activeTeamId, activeTeamId) || other.activeTeamId == activeTeamId));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Session&&(identical(other.id, id) || other.id == id)&&(identical(other.token, token) || other.token == token)&&(identical(other.expiresAt, expiresAt) || other.expiresAt == expiresAt)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.ipAddress, ipAddress) || other.ipAddress == ipAddress)&&(identical(other.userAgent, userAgent) || other.userAgent == userAgent)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.impersonatedBy, impersonatedBy) || other.impersonatedBy == impersonatedBy)&&(identical(other.activeOrganizationId, activeOrganizationId) || other.activeOrganizationId == activeOrganizationId)&&(identical(other.activeTeamId, activeTeamId) || other.activeTeamId == activeTeamId)&&const DeepCollectionEquality().equals(other._additionalFields, _additionalFields));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,token,expiresAt,createdAt,updatedAt,ipAddress,userAgent,userId,impersonatedBy,activeOrganizationId,activeTeamId);
+int get hashCode => Object.hash(runtimeType,id,token,expiresAt,createdAt,updatedAt,ipAddress,userAgent,userId,impersonatedBy,activeOrganizationId,activeTeamId,const DeepCollectionEquality().hash(_additionalFields));
 
 @override
 String toString() {
-  return 'Session(id: $id, token: $token, expiresAt: $expiresAt, createdAt: $createdAt, updatedAt: $updatedAt, ipAddress: $ipAddress, userAgent: $userAgent, userId: $userId, impersonatedBy: $impersonatedBy, activeOrganizationId: $activeOrganizationId, activeTeamId: $activeTeamId)';
+  return 'Session(id: $id, token: $token, expiresAt: $expiresAt, createdAt: $createdAt, updatedAt: $updatedAt, ipAddress: $ipAddress, userAgent: $userAgent, userId: $userId, impersonatedBy: $impersonatedBy, activeOrganizationId: $activeOrganizationId, activeTeamId: $activeTeamId, additionalFields: $additionalFields)';
 }
 
 
@@ -271,7 +291,7 @@ abstract mixin class _$SessionCopyWith<$Res> implements $SessionCopyWith<$Res> {
   factory _$SessionCopyWith(_Session value, $Res Function(_Session) _then) = __$SessionCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String token, DateTime expiresAt, DateTime? createdAt, DateTime? updatedAt, String? ipAddress, String? userAgent, String userId, String? impersonatedBy, String? activeOrganizationId, String? activeTeamId
+ String id, String token, DateTime expiresAt, DateTime? createdAt, DateTime? updatedAt, String? ipAddress, String? userAgent, String userId, String? impersonatedBy, String? activeOrganizationId, String? activeTeamId,@JsonKey(readValue: _readSessionAdditionalFields, includeToJson: false) Map<String, dynamic> additionalFields
 });
 
 
@@ -288,7 +308,7 @@ class __$SessionCopyWithImpl<$Res>
 
 /// Create a copy of Session
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? token = null,Object? expiresAt = null,Object? createdAt = freezed,Object? updatedAt = freezed,Object? ipAddress = freezed,Object? userAgent = freezed,Object? userId = null,Object? impersonatedBy = freezed,Object? activeOrganizationId = freezed,Object? activeTeamId = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? token = null,Object? expiresAt = null,Object? createdAt = freezed,Object? updatedAt = freezed,Object? ipAddress = freezed,Object? userAgent = freezed,Object? userId = null,Object? impersonatedBy = freezed,Object? activeOrganizationId = freezed,Object? activeTeamId = freezed,Object? additionalFields = null,}) {
   return _then(_Session(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,token: null == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
@@ -301,7 +321,8 @@ as String?,userId: null == userId ? _self.userId : userId // ignore: cast_nullab
 as String,impersonatedBy: freezed == impersonatedBy ? _self.impersonatedBy : impersonatedBy // ignore: cast_nullable_to_non_nullable
 as String?,activeOrganizationId: freezed == activeOrganizationId ? _self.activeOrganizationId : activeOrganizationId // ignore: cast_nullable_to_non_nullable
 as String?,activeTeamId: freezed == activeTeamId ? _self.activeTeamId : activeTeamId // ignore: cast_nullable_to_non_nullable
-as String?,
+as String?,additionalFields: null == additionalFields ? _self._additionalFields : additionalFields // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>,
   ));
 }
 

--- a/lib/core/models/session/session.g.dart
+++ b/lib/core/models/session/session.g.dart
@@ -22,6 +22,10 @@ _Session _$SessionFromJson(Map<String, dynamic> json) => _Session(
   impersonatedBy: json['impersonatedBy'] as String?,
   activeOrganizationId: json['activeOrganizationId'] as String?,
   activeTeamId: json['activeTeamId'] as String?,
+  additionalFields:
+      _readSessionAdditionalFields(json, 'additionalFields')
+          as Map<String, dynamic>? ??
+      const <String, dynamic>{},
 );
 
 Map<String, dynamic> _$SessionToJson(_Session instance) => <String, dynamic>{

--- a/lib/core/models/user/user.dart
+++ b/lib/core/models/user/user.dart
@@ -24,7 +24,47 @@ abstract class User with _$User {
     @Default(false) bool banned,
     String? banReason,
     DateTime? banExpires,
+
+    /// Server-defined custom fields ([`additionalFields`](https://www.better-auth.com/docs/concepts/database#extending-core-schema))
+    /// that aren't part of the static [User] shape. Populated from unmapped JSON
+    /// keys by [User.fromJson]; never serialized back out. Read via the `field`
+    /// extension, e.g. `user.field<String>('firstName')`.
+    @JsonKey(readValue: _readUserAdditionalFields, includeToJson: false)
+    @Default(<String, dynamic>{})
+    Map<String, dynamic> additionalFields,
   }) = _User;
 
   factory User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);
+}
+
+const _knownUserKeys = <String>{
+  'id',
+  'name',
+  'email',
+  'emailVerified',
+  'image',
+  'createdAt',
+  'updatedAt',
+  'twoFactorEnabled',
+  'username',
+  'displayUsername',
+  'isAnonymous',
+  'phoneNumber',
+  'phoneNumberVerified',
+  'role',
+  'banned',
+  'banReason',
+  'banExpires',
+};
+
+/// [JsonKey.readValue] for [User.additionalFields]: returns every server key
+/// the static model doesn't own — Better Auth merges `additionalFields` into
+/// the user object as flat top-level keys, so this collects the remainder.
+Map<String, dynamic> _readUserAdditionalFields(
+  Map<dynamic, dynamic> json,
+  String _,
+) {
+  final extra = Map<String, dynamic>.from(json)
+    ..removeWhere((key, _) => _knownUserKeys.contains(key));
+  return Map.unmodifiable(extra);
 }

--- a/lib/core/models/user/user.freezed.dart
+++ b/lib/core/models/user/user.freezed.dart
@@ -15,7 +15,11 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$User {
 
- String get id; String get name; String get email; bool get emailVerified; String? get image; DateTime? get createdAt; DateTime? get updatedAt; bool get twoFactorEnabled; String? get username; String? get displayUsername; bool get isAnonymous; String? get phoneNumber; bool get phoneNumberVerified; String? get role; bool get banned; String? get banReason; DateTime? get banExpires;
+ String get id; String get name; String get email; bool get emailVerified; String? get image; DateTime? get createdAt; DateTime? get updatedAt; bool get twoFactorEnabled; String? get username; String? get displayUsername; bool get isAnonymous; String? get phoneNumber; bool get phoneNumberVerified; String? get role; bool get banned; String? get banReason; DateTime? get banExpires;/// Server-defined custom fields ([`additionalFields`](https://www.better-auth.com/docs/concepts/database#extending-core-schema))
+/// that aren't part of the static [User] shape. Populated from unmapped JSON
+/// keys by [User.fromJson]; never serialized back out. Read via the `field`
+/// extension, e.g. `user.field<String>('firstName')`.
+@JsonKey(readValue: _readUserAdditionalFields, includeToJson: false) Map<String, dynamic> get additionalFields;
 /// Create a copy of User
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +32,16 @@ $UserCopyWith<User> get copyWith => _$UserCopyWithImpl<User>(this as User, _$ide
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is User&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.email, email) || other.email == email)&&(identical(other.emailVerified, emailVerified) || other.emailVerified == emailVerified)&&(identical(other.image, image) || other.image == image)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.twoFactorEnabled, twoFactorEnabled) || other.twoFactorEnabled == twoFactorEnabled)&&(identical(other.username, username) || other.username == username)&&(identical(other.displayUsername, displayUsername) || other.displayUsername == displayUsername)&&(identical(other.isAnonymous, isAnonymous) || other.isAnonymous == isAnonymous)&&(identical(other.phoneNumber, phoneNumber) || other.phoneNumber == phoneNumber)&&(identical(other.phoneNumberVerified, phoneNumberVerified) || other.phoneNumberVerified == phoneNumberVerified)&&(identical(other.role, role) || other.role == role)&&(identical(other.banned, banned) || other.banned == banned)&&(identical(other.banReason, banReason) || other.banReason == banReason)&&(identical(other.banExpires, banExpires) || other.banExpires == banExpires));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is User&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.email, email) || other.email == email)&&(identical(other.emailVerified, emailVerified) || other.emailVerified == emailVerified)&&(identical(other.image, image) || other.image == image)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.twoFactorEnabled, twoFactorEnabled) || other.twoFactorEnabled == twoFactorEnabled)&&(identical(other.username, username) || other.username == username)&&(identical(other.displayUsername, displayUsername) || other.displayUsername == displayUsername)&&(identical(other.isAnonymous, isAnonymous) || other.isAnonymous == isAnonymous)&&(identical(other.phoneNumber, phoneNumber) || other.phoneNumber == phoneNumber)&&(identical(other.phoneNumberVerified, phoneNumberVerified) || other.phoneNumberVerified == phoneNumberVerified)&&(identical(other.role, role) || other.role == role)&&(identical(other.banned, banned) || other.banned == banned)&&(identical(other.banReason, banReason) || other.banReason == banReason)&&(identical(other.banExpires, banExpires) || other.banExpires == banExpires)&&const DeepCollectionEquality().equals(other.additionalFields, additionalFields));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,email,emailVerified,image,createdAt,updatedAt,twoFactorEnabled,username,displayUsername,isAnonymous,phoneNumber,phoneNumberVerified,role,banned,banReason,banExpires);
+int get hashCode => Object.hash(runtimeType,id,name,email,emailVerified,image,createdAt,updatedAt,twoFactorEnabled,username,displayUsername,isAnonymous,phoneNumber,phoneNumberVerified,role,banned,banReason,banExpires,const DeepCollectionEquality().hash(additionalFields));
 
 @override
 String toString() {
-  return 'User(id: $id, name: $name, email: $email, emailVerified: $emailVerified, image: $image, createdAt: $createdAt, updatedAt: $updatedAt, twoFactorEnabled: $twoFactorEnabled, username: $username, displayUsername: $displayUsername, isAnonymous: $isAnonymous, phoneNumber: $phoneNumber, phoneNumberVerified: $phoneNumberVerified, role: $role, banned: $banned, banReason: $banReason, banExpires: $banExpires)';
+  return 'User(id: $id, name: $name, email: $email, emailVerified: $emailVerified, image: $image, createdAt: $createdAt, updatedAt: $updatedAt, twoFactorEnabled: $twoFactorEnabled, username: $username, displayUsername: $displayUsername, isAnonymous: $isAnonymous, phoneNumber: $phoneNumber, phoneNumberVerified: $phoneNumberVerified, role: $role, banned: $banned, banReason: $banReason, banExpires: $banExpires, additionalFields: $additionalFields)';
 }
 
 
@@ -48,7 +52,7 @@ abstract mixin class $UserCopyWith<$Res>  {
   factory $UserCopyWith(User value, $Res Function(User) _then) = _$UserCopyWithImpl;
 @useResult
 $Res call({
- String id, String name, String email, bool emailVerified, String? image, DateTime? createdAt, DateTime? updatedAt, bool twoFactorEnabled, String? username, String? displayUsername, bool isAnonymous, String? phoneNumber, bool phoneNumberVerified, String? role, bool banned, String? banReason, DateTime? banExpires
+ String id, String name, String email, bool emailVerified, String? image, DateTime? createdAt, DateTime? updatedAt, bool twoFactorEnabled, String? username, String? displayUsername, bool isAnonymous, String? phoneNumber, bool phoneNumberVerified, String? role, bool banned, String? banReason, DateTime? banExpires,@JsonKey(readValue: _readUserAdditionalFields, includeToJson: false) Map<String, dynamic> additionalFields
 });
 
 
@@ -65,7 +69,7 @@ class _$UserCopyWithImpl<$Res>
 
 /// Create a copy of User
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? email = null,Object? emailVerified = null,Object? image = freezed,Object? createdAt = freezed,Object? updatedAt = freezed,Object? twoFactorEnabled = null,Object? username = freezed,Object? displayUsername = freezed,Object? isAnonymous = null,Object? phoneNumber = freezed,Object? phoneNumberVerified = null,Object? role = freezed,Object? banned = null,Object? banReason = freezed,Object? banExpires = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? email = null,Object? emailVerified = null,Object? image = freezed,Object? createdAt = freezed,Object? updatedAt = freezed,Object? twoFactorEnabled = null,Object? username = freezed,Object? displayUsername = freezed,Object? isAnonymous = null,Object? phoneNumber = freezed,Object? phoneNumberVerified = null,Object? role = freezed,Object? banned = null,Object? banReason = freezed,Object? banExpires = freezed,Object? additionalFields = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -84,7 +88,8 @@ as bool,role: freezed == role ? _self.role : role // ignore: cast_nullable_to_no
 as String?,banned: null == banned ? _self.banned : banned // ignore: cast_nullable_to_non_nullable
 as bool,banReason: freezed == banReason ? _self.banReason : banReason // ignore: cast_nullable_to_non_nullable
 as String?,banExpires: freezed == banExpires ? _self.banExpires : banExpires // ignore: cast_nullable_to_non_nullable
-as DateTime?,
+as DateTime?,additionalFields: null == additionalFields ? _self.additionalFields : additionalFields // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>,
   ));
 }
 
@@ -169,10 +174,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name,  String email,  bool emailVerified,  String? image,  DateTime? createdAt,  DateTime? updatedAt,  bool twoFactorEnabled,  String? username,  String? displayUsername,  bool isAnonymous,  String? phoneNumber,  bool phoneNumberVerified,  String? role,  bool banned,  String? banReason,  DateTime? banExpires)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name,  String email,  bool emailVerified,  String? image,  DateTime? createdAt,  DateTime? updatedAt,  bool twoFactorEnabled,  String? username,  String? displayUsername,  bool isAnonymous,  String? phoneNumber,  bool phoneNumberVerified,  String? role,  bool banned,  String? banReason,  DateTime? banExpires, @JsonKey(readValue: _readUserAdditionalFields, includeToJson: false)  Map<String, dynamic> additionalFields)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _User() when $default != null:
-return $default(_that.id,_that.name,_that.email,_that.emailVerified,_that.image,_that.createdAt,_that.updatedAt,_that.twoFactorEnabled,_that.username,_that.displayUsername,_that.isAnonymous,_that.phoneNumber,_that.phoneNumberVerified,_that.role,_that.banned,_that.banReason,_that.banExpires);case _:
+return $default(_that.id,_that.name,_that.email,_that.emailVerified,_that.image,_that.createdAt,_that.updatedAt,_that.twoFactorEnabled,_that.username,_that.displayUsername,_that.isAnonymous,_that.phoneNumber,_that.phoneNumberVerified,_that.role,_that.banned,_that.banReason,_that.banExpires,_that.additionalFields);case _:
   return orElse();
 
 }
@@ -190,10 +195,10 @@ return $default(_that.id,_that.name,_that.email,_that.emailVerified,_that.image,
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name,  String email,  bool emailVerified,  String? image,  DateTime? createdAt,  DateTime? updatedAt,  bool twoFactorEnabled,  String? username,  String? displayUsername,  bool isAnonymous,  String? phoneNumber,  bool phoneNumberVerified,  String? role,  bool banned,  String? banReason,  DateTime? banExpires)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name,  String email,  bool emailVerified,  String? image,  DateTime? createdAt,  DateTime? updatedAt,  bool twoFactorEnabled,  String? username,  String? displayUsername,  bool isAnonymous,  String? phoneNumber,  bool phoneNumberVerified,  String? role,  bool banned,  String? banReason,  DateTime? banExpires, @JsonKey(readValue: _readUserAdditionalFields, includeToJson: false)  Map<String, dynamic> additionalFields)  $default,) {final _that = this;
 switch (_that) {
 case _User():
-return $default(_that.id,_that.name,_that.email,_that.emailVerified,_that.image,_that.createdAt,_that.updatedAt,_that.twoFactorEnabled,_that.username,_that.displayUsername,_that.isAnonymous,_that.phoneNumber,_that.phoneNumberVerified,_that.role,_that.banned,_that.banReason,_that.banExpires);case _:
+return $default(_that.id,_that.name,_that.email,_that.emailVerified,_that.image,_that.createdAt,_that.updatedAt,_that.twoFactorEnabled,_that.username,_that.displayUsername,_that.isAnonymous,_that.phoneNumber,_that.phoneNumberVerified,_that.role,_that.banned,_that.banReason,_that.banExpires,_that.additionalFields);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -210,10 +215,10 @@ return $default(_that.id,_that.name,_that.email,_that.emailVerified,_that.image,
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name,  String email,  bool emailVerified,  String? image,  DateTime? createdAt,  DateTime? updatedAt,  bool twoFactorEnabled,  String? username,  String? displayUsername,  bool isAnonymous,  String? phoneNumber,  bool phoneNumberVerified,  String? role,  bool banned,  String? banReason,  DateTime? banExpires)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name,  String email,  bool emailVerified,  String? image,  DateTime? createdAt,  DateTime? updatedAt,  bool twoFactorEnabled,  String? username,  String? displayUsername,  bool isAnonymous,  String? phoneNumber,  bool phoneNumberVerified,  String? role,  bool banned,  String? banReason,  DateTime? banExpires, @JsonKey(readValue: _readUserAdditionalFields, includeToJson: false)  Map<String, dynamic> additionalFields)?  $default,) {final _that = this;
 switch (_that) {
 case _User() when $default != null:
-return $default(_that.id,_that.name,_that.email,_that.emailVerified,_that.image,_that.createdAt,_that.updatedAt,_that.twoFactorEnabled,_that.username,_that.displayUsername,_that.isAnonymous,_that.phoneNumber,_that.phoneNumberVerified,_that.role,_that.banned,_that.banReason,_that.banExpires);case _:
+return $default(_that.id,_that.name,_that.email,_that.emailVerified,_that.image,_that.createdAt,_that.updatedAt,_that.twoFactorEnabled,_that.username,_that.displayUsername,_that.isAnonymous,_that.phoneNumber,_that.phoneNumberVerified,_that.role,_that.banned,_that.banReason,_that.banExpires,_that.additionalFields);case _:
   return null;
 
 }
@@ -225,7 +230,7 @@ return $default(_that.id,_that.name,_that.email,_that.emailVerified,_that.image,
 @JsonSerializable()
 
 class _User implements User {
-  const _User({required this.id, required this.name, required this.email, this.emailVerified = false, this.image, this.createdAt = null, this.updatedAt = null, this.twoFactorEnabled = false, this.username, this.displayUsername, this.isAnonymous = false, this.phoneNumber, this.phoneNumberVerified = false, this.role, this.banned = false, this.banReason, this.banExpires});
+  const _User({required this.id, required this.name, required this.email, this.emailVerified = false, this.image, this.createdAt = null, this.updatedAt = null, this.twoFactorEnabled = false, this.username, this.displayUsername, this.isAnonymous = false, this.phoneNumber, this.phoneNumberVerified = false, this.role, this.banned = false, this.banReason, this.banExpires, @JsonKey(readValue: _readUserAdditionalFields, includeToJson: false) final  Map<String, dynamic> additionalFields = const <String, dynamic>{}}): _additionalFields = additionalFields;
   factory _User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);
 
 @override final  String id;
@@ -245,6 +250,21 @@ class _User implements User {
 @override@JsonKey() final  bool banned;
 @override final  String? banReason;
 @override final  DateTime? banExpires;
+/// Server-defined custom fields ([`additionalFields`](https://www.better-auth.com/docs/concepts/database#extending-core-schema))
+/// that aren't part of the static [User] shape. Populated from unmapped JSON
+/// keys by [User.fromJson]; never serialized back out. Read via the `field`
+/// extension, e.g. `user.field<String>('firstName')`.
+ final  Map<String, dynamic> _additionalFields;
+/// Server-defined custom fields ([`additionalFields`](https://www.better-auth.com/docs/concepts/database#extending-core-schema))
+/// that aren't part of the static [User] shape. Populated from unmapped JSON
+/// keys by [User.fromJson]; never serialized back out. Read via the `field`
+/// extension, e.g. `user.field<String>('firstName')`.
+@override@JsonKey(readValue: _readUserAdditionalFields, includeToJson: false) Map<String, dynamic> get additionalFields {
+  if (_additionalFields is EqualUnmodifiableMapView) return _additionalFields;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(_additionalFields);
+}
+
 
 /// Create a copy of User
 /// with the given fields replaced by the non-null parameter values.
@@ -259,16 +279,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _User&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.email, email) || other.email == email)&&(identical(other.emailVerified, emailVerified) || other.emailVerified == emailVerified)&&(identical(other.image, image) || other.image == image)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.twoFactorEnabled, twoFactorEnabled) || other.twoFactorEnabled == twoFactorEnabled)&&(identical(other.username, username) || other.username == username)&&(identical(other.displayUsername, displayUsername) || other.displayUsername == displayUsername)&&(identical(other.isAnonymous, isAnonymous) || other.isAnonymous == isAnonymous)&&(identical(other.phoneNumber, phoneNumber) || other.phoneNumber == phoneNumber)&&(identical(other.phoneNumberVerified, phoneNumberVerified) || other.phoneNumberVerified == phoneNumberVerified)&&(identical(other.role, role) || other.role == role)&&(identical(other.banned, banned) || other.banned == banned)&&(identical(other.banReason, banReason) || other.banReason == banReason)&&(identical(other.banExpires, banExpires) || other.banExpires == banExpires));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _User&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.email, email) || other.email == email)&&(identical(other.emailVerified, emailVerified) || other.emailVerified == emailVerified)&&(identical(other.image, image) || other.image == image)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.twoFactorEnabled, twoFactorEnabled) || other.twoFactorEnabled == twoFactorEnabled)&&(identical(other.username, username) || other.username == username)&&(identical(other.displayUsername, displayUsername) || other.displayUsername == displayUsername)&&(identical(other.isAnonymous, isAnonymous) || other.isAnonymous == isAnonymous)&&(identical(other.phoneNumber, phoneNumber) || other.phoneNumber == phoneNumber)&&(identical(other.phoneNumberVerified, phoneNumberVerified) || other.phoneNumberVerified == phoneNumberVerified)&&(identical(other.role, role) || other.role == role)&&(identical(other.banned, banned) || other.banned == banned)&&(identical(other.banReason, banReason) || other.banReason == banReason)&&(identical(other.banExpires, banExpires) || other.banExpires == banExpires)&&const DeepCollectionEquality().equals(other._additionalFields, _additionalFields));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,email,emailVerified,image,createdAt,updatedAt,twoFactorEnabled,username,displayUsername,isAnonymous,phoneNumber,phoneNumberVerified,role,banned,banReason,banExpires);
+int get hashCode => Object.hash(runtimeType,id,name,email,emailVerified,image,createdAt,updatedAt,twoFactorEnabled,username,displayUsername,isAnonymous,phoneNumber,phoneNumberVerified,role,banned,banReason,banExpires,const DeepCollectionEquality().hash(_additionalFields));
 
 @override
 String toString() {
-  return 'User(id: $id, name: $name, email: $email, emailVerified: $emailVerified, image: $image, createdAt: $createdAt, updatedAt: $updatedAt, twoFactorEnabled: $twoFactorEnabled, username: $username, displayUsername: $displayUsername, isAnonymous: $isAnonymous, phoneNumber: $phoneNumber, phoneNumberVerified: $phoneNumberVerified, role: $role, banned: $banned, banReason: $banReason, banExpires: $banExpires)';
+  return 'User(id: $id, name: $name, email: $email, emailVerified: $emailVerified, image: $image, createdAt: $createdAt, updatedAt: $updatedAt, twoFactorEnabled: $twoFactorEnabled, username: $username, displayUsername: $displayUsername, isAnonymous: $isAnonymous, phoneNumber: $phoneNumber, phoneNumberVerified: $phoneNumberVerified, role: $role, banned: $banned, banReason: $banReason, banExpires: $banExpires, additionalFields: $additionalFields)';
 }
 
 
@@ -279,7 +299,7 @@ abstract mixin class _$UserCopyWith<$Res> implements $UserCopyWith<$Res> {
   factory _$UserCopyWith(_User value, $Res Function(_User) _then) = __$UserCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String name, String email, bool emailVerified, String? image, DateTime? createdAt, DateTime? updatedAt, bool twoFactorEnabled, String? username, String? displayUsername, bool isAnonymous, String? phoneNumber, bool phoneNumberVerified, String? role, bool banned, String? banReason, DateTime? banExpires
+ String id, String name, String email, bool emailVerified, String? image, DateTime? createdAt, DateTime? updatedAt, bool twoFactorEnabled, String? username, String? displayUsername, bool isAnonymous, String? phoneNumber, bool phoneNumberVerified, String? role, bool banned, String? banReason, DateTime? banExpires,@JsonKey(readValue: _readUserAdditionalFields, includeToJson: false) Map<String, dynamic> additionalFields
 });
 
 
@@ -296,7 +316,7 @@ class __$UserCopyWithImpl<$Res>
 
 /// Create a copy of User
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? email = null,Object? emailVerified = null,Object? image = freezed,Object? createdAt = freezed,Object? updatedAt = freezed,Object? twoFactorEnabled = null,Object? username = freezed,Object? displayUsername = freezed,Object? isAnonymous = null,Object? phoneNumber = freezed,Object? phoneNumberVerified = null,Object? role = freezed,Object? banned = null,Object? banReason = freezed,Object? banExpires = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? email = null,Object? emailVerified = null,Object? image = freezed,Object? createdAt = freezed,Object? updatedAt = freezed,Object? twoFactorEnabled = null,Object? username = freezed,Object? displayUsername = freezed,Object? isAnonymous = null,Object? phoneNumber = freezed,Object? phoneNumberVerified = null,Object? role = freezed,Object? banned = null,Object? banReason = freezed,Object? banExpires = freezed,Object? additionalFields = null,}) {
   return _then(_User(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -315,7 +335,8 @@ as bool,role: freezed == role ? _self.role : role // ignore: cast_nullable_to_no
 as String?,banned: null == banned ? _self.banned : banned // ignore: cast_nullable_to_non_nullable
 as bool,banReason: freezed == banReason ? _self.banReason : banReason // ignore: cast_nullable_to_non_nullable
 as String?,banExpires: freezed == banExpires ? _self.banExpires : banExpires // ignore: cast_nullable_to_non_nullable
-as DateTime?,
+as DateTime?,additionalFields: null == additionalFields ? _self._additionalFields : additionalFields // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>,
   ));
 }
 

--- a/lib/core/models/user/user.g.dart
+++ b/lib/core/models/user/user.g.dart
@@ -30,6 +30,10 @@ _User _$UserFromJson(Map<String, dynamic> json) => _User(
   banExpires: json['banExpires'] == null
       ? null
       : DateTime.parse(json['banExpires'] as String),
+  additionalFields:
+      _readUserAdditionalFields(json, 'additionalFields')
+          as Map<String, dynamic>? ??
+      const <String, dynamic>{},
 );
 
 Map<String, dynamic> _$UserToJson(_User instance) => <String, dynamic>{

--- a/lib/flutter_better_auth.dart
+++ b/lib/flutter_better_auth.dart
@@ -52,6 +52,7 @@ export 'core/api/models/result/result.dart';
 export 'core/api/models/result/result_extension.dart';
 export 'core/api/models/session/session_response.dart';
 export 'core/api/better_auth_client.dart';
+export 'core/api/better_auth_client_extension.dart';
 export 'core/flutter_better_auth.dart';
 export 'core/storage/storage.dart';
 export 'core/storage/secure_storage.dart';
@@ -61,6 +62,7 @@ export 'core/models/account/account.dart';
 export 'core/models/session/session.dart';
 // DEFAULT MODEL
 
+export 'core/models/additional_fields.dart';
 export 'core/models/user/user.dart';
 export 'core/models/verification/verification.dart';
 export 'presentation/better_auth_consumer.dart';

--- a/test/additional_fields_test.dart
+++ b/test/additional_fields_test.dart
@@ -1,0 +1,176 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_better_auth/core/api/default/sign_up/sign_up_better_auth.dart';
+import 'package:flutter_better_auth/core/api/default/sign_up/sign_up_extension.dart';
+import 'package:flutter_better_auth/core/models/additional_fields.dart';
+import 'package:flutter_better_auth/core/models/session/session.dart';
+import 'package:flutter_better_auth/core/models/user/user.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('User.additionalFields', () {
+    test('collects unmapped server keys alongside the static fields', () {
+      final user = User.fromJson(<String, dynamic>{
+        'id': 'u1',
+        'name': 'Jane',
+        'email': 'j@x.io',
+        'emailVerified': true,
+        // Better Auth additionalFields — flat-merged into the user object.
+        'firstName': 'Jane',
+        'lastName': 'Doe',
+        'lang': 'fr',
+      });
+
+      expect(user.id, 'u1');
+      expect(user.email, 'j@x.io');
+      expect(user.emailVerified, isTrue);
+      expect(user.additionalFields['firstName'], 'Jane');
+      expect(user.additionalFields['lastName'], 'Doe');
+      expect(user.additionalFields['lang'], 'fr');
+    });
+
+    test('is empty when the payload has no custom fields', () {
+      final user = User.fromJson(<String, dynamic>{
+        'id': 'u1',
+        'name': 'Jane',
+        'email': 'j@x.io',
+      });
+      expect(user.additionalFields, isEmpty);
+    });
+
+    test('does not leak a static field name into the map', () {
+      final user = User.fromJson(<String, dynamic>{
+        'id': 'u1',
+        'name': 'Jane',
+        'email': 'j@x.io',
+        'role': 'admin',
+      });
+      // `role` is a known field, so it must map to `user.role`, not the map.
+      expect(user.role, 'admin');
+      expect(user.additionalFields.containsKey('role'), isFalse);
+    });
+
+    test('is unmodifiable', () {
+      final user = User.fromJson(<String, dynamic>{
+        'id': 'u1',
+        'name': 'Jane',
+        'email': 'j@x.io',
+        'firstName': 'Jane',
+      });
+      expect(
+        () => user.additionalFields['lastName'] = 'Doe',
+        throwsUnsupportedError,
+      );
+    });
+  });
+
+  group('field<T>() accessor', () {
+    final user = User.fromJson(<String, dynamic>{
+      'id': 'u1',
+      'name': 'Jane',
+      'email': 'j@x.io',
+      'firstName': 'Jane',
+      'loginCount': 42,
+      'prefs': <String, dynamic>{'theme': 'dark'},
+    });
+
+    test('returns a typed value', () {
+      expect(user.field<String>('firstName'), 'Jane');
+      expect(user.field<int>('loginCount'), 42);
+    });
+
+    test('returns null for an absent key', () {
+      expect(user.field<String>('missing'), isNull);
+      expect(user.field<String>('missing') ?? 'fallback', 'fallback');
+    });
+
+    test('decodes nested JSON via decode', () {
+      final prefs = user.field<Map<String, dynamic>>('prefs');
+      expect(prefs?['theme'], 'dark');
+    });
+
+    test('throws when the value is not assignable to T', () {
+      expect(() => user.field<String>('loginCount'), throwsA(isA<ArgumentError>()));
+    });
+  });
+
+  group('Session.additionalFields', () {
+    test('collects unmapped server keys', () {
+      final session = Session.fromJson(<String, dynamic>{
+        'id': 's1',
+        'token': 'tok',
+        'expiresAt': '2026-12-31T00:00:00.000Z',
+        'userId': 'u1',
+        'theme': 'dark',
+        'language': 'fr',
+      });
+
+      expect(session.userId, 'u1');
+      expect(session.additionalFields['theme'], 'dark');
+      expect(session.field<String>('language'), 'fr');
+    });
+  });
+
+  group('signUp.email write path', () {
+    test('flat-merges additionalFields as top-level body keys', () async {
+      Object? sentBody;
+      final dio = Dio(BaseOptions(baseUrl: 'http://test'))
+        ..interceptors.add(
+          InterceptorsWrapper(
+            onRequest: (options, handler) {
+              sentBody = options.data;
+              handler.next(options);
+            },
+          ),
+        )
+        ..httpClientAdapter = _SignUpOkAdapter();
+
+      final signUp = SignUpBetterAuth(dio, baseUrl: 'http://test');
+      await signUp.email(
+        name: 'Jane',
+        email: 'a@b.c',
+        password: 'pw',
+        additionalFields: <String, dynamic>{
+          'firstName': 'Jane',
+          'lastName': 'Doe',
+        },
+      );
+
+      // Custom fields must be siblings of name/email/password — never nested —
+      // because Better Auth reads them as flat top-level keys.
+      expect(sentBody, <String, dynamic>{
+        'name': 'Jane',
+        'email': 'a@b.c',
+        'password': 'pw',
+        'firstName': 'Jane',
+        'lastName': 'Doe',
+      });
+    });
+  });
+}
+
+/// Returns a minimal valid `SignUpResponse` payload so the call completes.
+class _SignUpOkAdapter implements HttpClientAdapter {
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    final body = jsonEncode(<String, dynamic>{
+      'token': null,
+      'user': <String, dynamic>{'id': '1', 'name': 'n', 'email': 'e@e.e'},
+    });
+    return ResponseBody.fromString(
+      body,
+      200,
+      headers: <String, List<String>>{
+        Headers.contentTypeHeader: <String>['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}

--- a/test/additional_fields_test.dart
+++ b/test/additional_fields_test.dart
@@ -72,7 +72,8 @@ void main() {
       'email': 'j@x.io',
       'firstName': 'Jane',
       'loginCount': 42,
-      'prefs': <String, dynamic>{'theme': 'dark'},
+      // Stored as a JSON string so `field()` needs the decode callback to read it.
+      'prefs': jsonEncode(<String, dynamic>{'theme': 'dark'}),
     });
 
     test('returns a typed value', () {
@@ -86,7 +87,10 @@ void main() {
     });
 
     test('decodes nested JSON via decode', () {
-      final prefs = user.field<Map<String, dynamic>>('prefs');
+      final prefs = user.field<Map<String, dynamic>>(
+        'prefs',
+        decode: (value) => jsonDecode(value as String) as Map<String, dynamic>,
+      );
       expect(prefs?['theme'], 'dark');
     });
 


### PR DESCRIPTION
Custom user and session fields declared through Better Auth's additionalFields were being dropped on read, and there was no way to send them on sign-up, sign-in, or update. This wires up both directions.

For reading, User and Session now keep an `additionalFields` map holding every server key the static models don't claim, plus a typed `field<T>()` accessor so you can write `user.field<String>('firstName')` instead of casting out of a map. The map is filled via json_serializable's readValue hook — a custom fromJson body silently suppresses the generated .g.dart entirely.

For writing, signUp.email, signIn.email/username, and updateUser take an `additionalFields` map that's flat-merged into the request body (Better Auth wants these as top-level keys, not nested). The retrofit methods became `*Raw` variants taking a `@Body Map`, with typed extension wrappers on top — the same layout `signIn.social` and the organization plugin already use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom user and session fields through `additionalFields`.
  * Added typed field accessors with optional decoding for custom data.
  * Sign-up, sign-in, and user updates now support submitting additional fields.
  * Added raw request options for advanced request payloads.
* **Documentation**
  * Added guidance for reading, writing, defaulting, and extending custom fields.
  * Documented handling of fields excluded from client responses.
* **Tests**
  * Added coverage for custom field collection, typed access, validation, and sign-up payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->