### PR TITLE
fix: update forgotPassword endpoint to /request-password-reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 0.6.4
+
+**Fixed**
+
+- `forgotPassword()` now calls Better Auth's `/request-password-reset` endpoint instead of the removed `/forget-password`, matching the endpoint rename in Better Auth 1.6.27.
+
+
 ### 0.6.3
 
 **Added**

--- a/lib/core/api/better_auth_client.dart
+++ b/lib/core/api/better_auth_client.dart
@@ -31,7 +31,7 @@ abstract class BetterAuthClient {
     @Body(nullToAbsent: true) Map<String, dynamic> body = const {},
   });
 
-  @POST('/forget-password')
+  @POST('/request-password-reset')
   Future<Result<StatusResponse>> forgotPassword({
     @BodyExtra('email') required String email,
     @BodyExtra('redirectTo') String? redirectTo,

--- a/lib/core/api/better_auth_client.g.dart
+++ b/lib/core/api/better_auth_client.g.dart
@@ -107,7 +107,7 @@ class _BetterAuthClient implements BetterAuthClient {
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            '/forget-password',
+            '/request-password-reset',
             queryParameters: queryParameters,
             data: _data,
           )

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_better_auth
 description: A Dart/Flutter client for the Better Auth platform, enabling secure sign-in, sign-up, and session management in Flutter applications.
-version: 0.6.3
+version: 0.6.4
 homepage: https://github.com/tsiresymila1/flutter_better_auth.git
 
 environment:


### PR DESCRIPTION
## Summary
- Better Auth 1.6.27 renamed the `/forget-password` endpoint to `/request-password-reset`; `BetterAuthClient.forgotPassword()` now targets the new path.
- Bumped package version to 0.6.4 and added a CHANGELOG entry.

## Test plan
- [x] `flutter pub get`
- [x] `flutter analyze`
- [x] Manually verify `forgotPassword()` hits `/request-password-reset` against a Better Auth 1.6.27+ server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated password reset requests to use Better Auth’s current endpoint, restoring compatibility with password recovery.

* **Documentation**
  * Added release notes for version 0.6.4.

* **Chores**
  * Incremented the package version to 0.6.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->