### PR TITLE
feat: add requestPasswordReset endpoint to EmailOTP plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 0.6.5
+
+**Added**
+
+- Support for requesting a password reset OTP via `client.emailOtp.requestPasswordReset(email:)` (`POST /email-otp/request-password-reset`).
+
 ### 0.6.4
 
 **Fixed**

--- a/lib/plugins/email_otp/email_otp_better_auth.dart
+++ b/lib/plugins/email_otp/email_otp_better_auth.dart
@@ -39,6 +39,12 @@ abstract class EmailOtpBetterAuth {
     @BodyExtra('email') required String email,
   });
 
+  /// Requests a password reset OTP sent to the specified [email].
+  @POST('/email-otp/request-password-reset')
+  Future<Result<SuccessResponse>> requestPasswordReset({
+    @BodyExtra('email') required String email,
+  });
+
   @POST('/email-otp/reset-password')
   Future<Result<SuccessResponse>> resetPassword({
     @BodyExtra('email') required String email,

--- a/lib/plugins/email_otp/email_otp_better_auth.g.dart
+++ b/lib/plugins/email_otp/email_otp_better_auth.g.dart
@@ -175,6 +175,44 @@ class _EmailOtpBetterAuth implements EmailOtpBetterAuth {
     );
   }
 
+  Future<HttpResponse<SuccessResponse>> _requestPasswordReset({
+    required String email,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{'email': email};
+    final _options = _setStreamType<Result<SuccessResponse>>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/email-otp/request-password-reset',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late SuccessResponse _value;
+    try {
+      _value = SuccessResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<Result<SuccessResponse>> requestPasswordReset({
+    required String email,
+  }) {
+    return BetterAuthCallAdapter<SuccessResponse>().adapt(
+      () => _requestPasswordReset(email: email),
+    );
+  }
+
   Future<HttpResponse<SuccessResponse>> _resetPassword({
     required String email,
     required String otp,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_better_auth
 description: A Dart/Flutter client for the Better Auth platform, enabling secure sign-in, sign-up, and session management in Flutter applications.
-version: 0.6.4
+version: 0.6.5
 homepage: https://github.com/tsiresymila1/flutter_better_auth.git
 
 environment:


### PR DESCRIPTION
## Summary
- Adds the `requestPasswordReset` endpoint (`POST /email-otp/request-password-reset`) to `EmailOtpBetterAuth` to support requesting a password reset OTP via email in Better Auth.
- Regenerates `email_otp_better_auth.g.dart` using Retrofit generator.

## Changes
- `lib/plugins/email_otp/email_otp_better_auth.dart`: Added `requestPasswordReset` API definition returning `Result<SuccessResponse>`.
- `lib/plugins/email_otp/email_otp_better_auth.g.dart`: Generated Retrofit implementation for `POST /email-otp/request-password-reset`.

## Test Plan
- [x] Ran `dart run build_runner build`
- [x] Ran `dart analyze lib/plugins/email_otp`
- [x] Ran `flutter test` (all tests passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for requesting a password-reset OTP using an email address.
  - Requests now return a success response when the password-reset email is initiated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->